### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ That's the problem freshcontext fixes.
 [![npm version](https://img.shields.io/npm/v/freshcontext-mcp)](https://www.npmjs.com/package/freshcontext-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+<a href="https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badge" alt="freshcontext-mcp MCP server" />
+</a>
+
 ---
 
 ## What it does


### PR DESCRIPTION
This PR adds a badge for the [freshcontext-mcp](https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@PrinceGabriel-lgtm/freshcontext-mcp/badge" alt="freshcontext-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.