### PR TITLE
fix: harden MCP install pathways for 0.3.17

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,7 +15,14 @@ src/
 worker/
 
 # Development docs (not needed by npm consumers)
+.claude/
+.github/
 _archive/
+CLAUDE.md
+AUDIT_*.md
+PASS_*.md
+RESEARCH.md
+RISKS.md
 SESSION_SAVE_*.md
 HANDOFF.md
 ARCHITECTURE_UPGRADE_*.md
@@ -26,6 +33,14 @@ METHODOLOGY.md
 FRESHCONTEXT_SPEC.md
 ROADMAP.md
 USAGE.md
+TIME_CHECK_README.md
+
+# Repo-only smoke/demo/development helpers
+scripts/
+demo/
+cleanup.ps1
+time-check.ps1
+freshcontext-validate.js
 
 # Database snapshots
 backup.sql

--- a/AUDIT_PASS4.md
+++ b/AUDIT_PASS4.md
@@ -18,7 +18,7 @@ So "proper envelope" at the adapter layer means: the adapter returns the structu
 |---|---|---|---|---|---|---|---|
 | 1 | `arxiv` | ❌ no | ❌ imported but not registered | ✅ yes | ✅ ISO date (YYYY-MM-DD) from `<published>` | ✅ high/medium/low | None observed. Used only via composites (none in server.ts use it). |
 | 2 | `changelog` | ❌ no | ✅ `extract_changelog` | ✅ yes | ✅ ISO from GitHub Releases / npm; medium-conf scrape extracts dates from page text | ✅ all three values used | Discovery scraper has `low` confidence when scrape returns no dates — acceptable. |
-| 3 | `finance` | ✅ `extract_finance` | ❌ imported but not registered (used only via `extract_finance_landscape`) | ✅ yes | ✅ ISO from `regularMarketTime` (Yahoo); falls back to `now()` | ✅ always `"high"` | Always-`high` confidence even on `now()` fallback is mildly optimistic; not blocking. |
+| 3 | `finance` | ✅ `extract_finance` | ❌ imported but not registered (used only via `extract_finance_landscape`) | ✅ yes | Historical note: older quote source used provider timestamps and could fall back to `now()` | ✅ always `"high"` | Superseded by Pass 0.3.17 finance failure-honesty fix. |
 | 4 | `gdelt` | ❌ no | ✅ `extract_gdelt` | ✅ yes | ✅ ISO parsed from GDELT `seendate` (YYYYMMDDTHHMMSSZ) | ✅ always `"high"` | None. |
 | 5 | `gebiz` | ❌ no | ✅ `extract_gebiz` | ✅ yes | ✅ ISO converted from DD/MM/YYYY | ✅ always `"high"` | Locale-quirk: assumes DD/MM/YYYY. If data.gov.sg returns ISO it falls back to `slice(0,10)`. Acceptable. |
 | 6 | `github` | ✅ `extract_github` | ✅ `extract_github` | ✅ yes | ✅ ISO from `<relative-time datetime>` | ✅ high if commit found, medium otherwise | None. |
@@ -93,7 +93,7 @@ If the brief author considers any inline ISO date in `raw` to itself be the bug,
 - **worker.ts** defines its own simplified `stamp()` envelope (no `[FRESHCONTEXT_JSON]` block, no `freshness_score` line, content slice hard-coded to 6000). The npm package's `formatForLLM` is fuller. This divergence is pre-existing and out of scope for Pass 4.
 - **worker.ts** `extract_landscape` does not call the actual adapter functions — it inlines `fetch` calls. Porting work in Phase 3 will need to decide: (a) port adapter modules into `worker/src/`, then have composites call them, or (b) keep inlining. Existing 11 tools all inline. I recommend matching the existing pattern (inline) for the 9 wired-in adapters in Phase 3, rather than introducing a new module structure mid-stream.
 - **Hard-coded PH token** at `src/adapters/productHunt.ts:57`. Already on public npm. Should be rotated or moved to env eventually. Not in Pass 4 scope.
-- **Worker `extract_finance` uses adapter name `"yahoo_finance"`** (`worker.ts:522`) but `intelligence.ts` decay table keys it as `"finance"` (rate 5.0). Mismatch → falls through to default decay 1.5. Confirmed by reading `freshnessStamp.ts:9` (`finance: 5.0`). Pre-existing. Worth fixing in Phase 2 since it's a one-character typo with real DAR consequences. Confirm the worker side wants to use `"finance"` as the key (as the npm path does).
+- **Worker `extract_finance` previously used a provider-specific adapter name** (`worker.ts:522`) but `intelligence.ts` decay table keys it as `"finance"`. Mismatch → falls through to default decay. Fixed in later pass; worker and npm now use `"finance"`.
 
 ## Summary
 
@@ -102,7 +102,7 @@ If the brief author considers any inline ISO date in `raw` to itself be the bug,
 - **1 ghost bug from the brief** (BUG-2: HN inline timestamps — not currently happening; structured `content_date` is set correctly).
 - **4 missing `registerTool` calls** in `src/server.ts` (arxiv, finance, reddit, productHunt) — pure addition work for Phase 2, no ambiguity.
 - **6 base adapters** still need wiring into the Worker (arxiv, changelog, gdelt, gebiz, govcontracts, secFilings). Plus **4 composites** (gov_landscape, finance_landscape, company_landscape, idea_landscape).
-- **1 worth-flagging adapter-key typo** (worker `extract_finance` stamps `"yahoo_finance"` instead of `"finance"` → wrong DAR decay rate). One-line fix candidate for Phase 2 if you want it bundled.
+- **1 worth-flagging adapter-key typo** (worker `extract_finance` stamped a provider-specific adapter name instead of `"finance"` → wrong DAR decay rate). Fixed in later pass.
 
 Worker currently has 11 tools registered. Target: 21. Missing: 10 registrations (6 base + 4 composites).
 

--- a/AUDIT_PASS5.md
+++ b/AUDIT_PASS5.md
@@ -89,7 +89,7 @@ Pass 5's goal as written ("port npm `formatForLLM` into the worker") cannot be d
 
 - **Option B — keep exponential, port the worker's LAMBDA into the envelope.** The numbers stay consistent across the system (envelope and intel feed both reflect the engine). But the npm package and the worker would emit different freshness scores for identical content — same npm `extract_hackernews` and worker `extract_hackernews` would disagree by ~70 points on a 1-day-old story.
 
-- **Option C — make both packages exponential, treat npm as out of date.** The spec (`METHODOLOGY.md`) says exponential. Update the npm package's `freshnessStamp.ts` to match the worker's LAMBDA. This requires releasing a new npm version (`0.3.16`), but yields one consistent model across the project.
+- **Option C — make both packages exponential, treat npm as out of date.** The spec (`METHODOLOGY.md`) says exponential. Update the npm package's `freshnessStamp.ts` to match the worker's LAMBDA. This requires a new npm release, but yields one consistent model across the project.
 
 - **Option D — make both packages linear, treat worker engine as out of spec.** Pull npm's table down into worker, replace `LAMBDA` and `applyDecay()` with linear math. Larger blast radius — affects cron, intel feed, briefing scoring, all D1 stored values. Probably not desirable.
 

--- a/FRESHCONTEXT_SPEC.md
+++ b/FRESHCONTEXT_SPEC.md
@@ -89,13 +89,13 @@ Implementations MAY additionally expose freshness metadata as structured JSON al
 
 ### `freshness_score` (optional)
 
-A numeric representation of data freshness from 0–100, calculated as:
+A numeric representation of data freshness from 0–100. The canonical reference implementation uses exponential, source-specific temporal decay:
 
 ```
-freshness_score = max(0, 100 - (days_since_retrieved × decay_rate))
+R(t) = R0 · e^(-λt)
 ```
 
-Where `decay_rate` defaults to `1.5` for general web content. Implementations MAY use domain-specific decay rates to reflect how quickly different categories of data become unreliable.
+For envelope-level `freshness_score`, `R0` is normalised to `100`; for ranked intelligence feeds, `R0` is the semantic base score. Implementations MAY use domain-specific λ values to reflect how quickly different categories of data become unreliable.
 
 #### Recommended Decay Rates by Domain
 
@@ -195,13 +195,13 @@ Partial implementations that include only `retrieved_at` without `freshness_conf
 
 The canonical reference implementation of this specification is:
 
-**freshcontext-mcp** — an MCP server with 20 adapters covering:
+**freshcontext-mcp** — an MCP server with 21 tools covering:
 
 **Intelligence:** GitHub, Hacker News, Google Scholar, arXiv, Reddit
 
 **Competitive research:** YC Companies, Product Hunt, GitHub repo search, npm/PyPI package trends
 
-**Market data:** Yahoo Finance (up to 5 tickers), job listings (Remotive, RemoteOK, HN Hiring)
+**Market data:** Stooq quote data (up to 5 tickers), job listings (Remotive, RemoteOK, HN Hiring)
 
 **Unique — not available in any other MCP server:**
 - `extract_changelog` — release history from any repo, npm package, or website
@@ -227,7 +227,7 @@ The canonical reference implementation of this specification is:
 - Added Composite Adapters section
 - Added domain-specific decay rate table with recommended values
 - Added Compatibility Levels table (compatible / aware / scored)
-- Updated reference implementation to 20 adapters
+- Updated reference implementation to 21 tools
 - Added `extract_gdelt`, `extract_gebiz`, `extract_sec_filings` to high-confidence examples
 - Added Apify Store and MCP Registry to reference implementation listings
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -41,7 +41,7 @@ FreshContext implements 11 production adapters covering the following sources:
 | `reddit` | Reddit JSON API | None | Real-time |
 | `yc` | YC Open Source API | None | Per batch cycle |
 | `packagetrends` | npm Registry + npm Downloads API | None | Per publish |
-| `finance` | Yahoo Finance API | None | Market hours |
+| `finance` | Stooq quote API | None | Market hours / quote feed cadence |
 | `hackernews` | HN Algolia Full-Text Search | None | Real-time |
 
 All adapters operate exclusively on **publicly accessible data**. No credentials are required or used for data access. All fetch requests include a `User-Agent` header identifying the FreshContext crawler.
@@ -269,7 +269,7 @@ For acquirers, investors, and licensing partners:
 
 5. **The Historical D1 Ledger** (data asset) — the continuously accumulating time-series dataset. As of the date of this document, the ledger has been running since early 2026 with 6-hour collection intervals across 18 watched queries. The dataset grows in defensibility with every passing day.
 
-6. **The Reference Implementation** — `freshcontext-mcp@0.3.16`, listed on the official MCP Registry and npm. Deployed globally on Cloudflare's edge infrastructure.
+6. **The Reference Implementation** — `freshcontext-mcp@0.3.17`, listed on the official MCP Registry and npm. Deployed globally on Cloudflare's edge infrastructure.
 
 ---
 

--- a/PASS_5_BRIEF.md
+++ b/PASS_5_BRIEF.md
@@ -30,7 +30,7 @@ For the Worker:
 
 1. Confirm the gap: does *every* tool path call `stamp()`? Are there any direct envelope strings written elsewhere (composites, briefing, intel feed)?
 2. Compare DAR decay rates between `src/tools/freshnessStamp.ts` (`DECAY_RATES`) and `worker/src/intelligence.ts`. They must agree. If they disagree, list the differences and flag — do not fix in Phase 1.
-3. Check every adapter name passed to `stamp()` (in worker.ts) against the DAR rate table. Pass 4 Phase 2 fixed one (`yahoo_finance` → `finance`). Sweep the remaining 20 to confirm none silently fall through to default rate `1.5`.
+3. Check every adapter name passed to `stamp()` (in worker.ts) against the DAR rate table. Pass 4 Phase 2 fixed one provider-specific finance key to `finance`. Sweep the remaining tools to confirm none silently fall through to the default rate.
 4. Spot anywhere downstream that parses the envelope (e.g. cron job, intel feed, briefing synthesis) and might break if a `Score:` line and a trailing `[FRESHCONTEXT_JSON]` block are appended. Listing-only — do not change.
 
 **Output of Phase 1:** Markdown report `AUDIT_PASS5.md` at repo root. Include:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ R_t = R_0 · e^(−λt)
 
 That's the whole fix. No model swap. No re-embedding. No re-indexing. The layer drops onto whatever retrieval pipeline you already have.
 
-**The layer is the product.** The 20 adapters shipped with this repo are reference implementations demonstrating compatibility — useful, but commodity. The DAR engine, the freshness envelope, and the FreshContext Specification are the moat.
+**The layer is the product.** The 21 tools shipped with this repo are reference implementations demonstrating compatibility — useful, but commodity. The DAR engine, the freshness envelope, and the FreshContext Specification are the moat.
 
 ---
 
@@ -82,7 +82,7 @@ Production endpoint: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
 ## Reference adapters
 
-The repo ships 20 adapters demonstrating how to make any data source FreshContext-compatible. Useful as drop-in tools, but the value is the layer above them.
+The repo ships 21 tools demonstrating how to make any data source FreshContext-compatible. Useful as drop-in tools, but the value is the layer above them.
 
 ### Intelligence
 | Adapter | What it returns |
@@ -104,7 +104,7 @@ The repo ships 20 adapters demonstrating how to make any data source FreshContex
 ### Market data
 | Adapter | What it returns |
 |---|---|
-| `extract_finance` | Live stock data — price, market cap, P/E, 52w range. Up to 5 tickers. |
+| `extract_finance` | No-key Stooq quote data — close, OHLC, volume, quote timestamp, source. Up to 5 tickers. |
 | `search_jobs` | Remote job listings from Remotive, RemoteOK, HN "Who is Hiring" |
 
 ### Composites — multiple sources, one call
@@ -259,12 +259,12 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 ## Roadmap
 
 - [x] FreshContext Specification v1.1 published (MIT, open standard)
-- [x] DAR engine with proprietary λ constants (v0.3.16)
+- [x] DAR engine with proprietary λ constants (v0.3.17)
 - [x] Ha-Pri audit signatures on every signal
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`
 - [x] METHODOLOGY.md — formal IP and engineering documentation
-- [x] 20 reference adapters across intelligence, competitive research, market data, and composites
+- [x] 21 reference tools across intelligence, competitive research, market data, and composites
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
 - [x] Listed on official MCP Registry, Apify Store, npm
 - [x] GitHub Actions CI/CD — auto-publish on every push

--- a/USAGE.md
+++ b/USAGE.md
@@ -275,7 +275,7 @@ The gap between `Published` and `Retrieved` is your staleness indicator. If a jo
 A numeric score from 0–100 will be added to every result:
 
 ```
-freshness_score = max(0, 100 - (days_since_retrieved × decay_rate))
+R(t) = R0 · e^(-λt)
 ```
 
 Different data types decay at different rates — financial data goes stale faster than academic papers. You'll be able to filter results by `freshness_score > 70` directly in your prompts.

--- a/freshcontext.schema.json
+++ b/freshcontext.schema.json
@@ -36,7 +36,7 @@
           "type": ["number", "null"],
           "minimum": 0,
           "maximum": 100,
-          "description": "Optional numeric freshness score 0-100. Calculated as: max(0, 100 - (days_since_retrieved * decay_rate)). Null if content_date is unknown.",
+          "description": "Optional numeric freshness score 0-100. Calculated with source-specific exponential temporal decay. Null if content_date is unknown.",
           "examples": [94, 72, 45, null]
         },
         "adapter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshcontext-mcp",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshcontext-mcp",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freshcontext-mcp",
   "mcpName": "io.github.PrinceGabriel-lgtm/freshcontext",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Real-time web intelligence for AI agents. 21 tools, no required API keys. Every result timestamped with a freshness score.",
   "keywords": [
     "mcp",
@@ -36,6 +36,7 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
+    "smoke:stdio": "node scripts/smoke-stdio.mjs",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/smoke-stdio.mjs
+++ b/scripts/smoke-stdio.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const pkg = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function textOf(result) {
+  return (result.content ?? [])
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function parseFreshContextJson(text) {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  assert(match, "Missing [FRESHCONTEXT_JSON] block");
+  return JSON.parse(match[1]);
+}
+
+function assertNoMisleadingFailureEnvelope(text, label) {
+  if (/\b(?:Error|ERROR|401|403|404|429|failed)\b/.test(text)) {
+    assert(!/Confidence:\s*high/i.test(text), `${label}: failure content must not be Confidence: high`);
+    assert(!/Score:\s*100\/100/i.test(text), `${label}: failure content must not be Score: 100/100`);
+  }
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [resolve(root, "dist/server.js")],
+  cwd: root,
+  stderr: "pipe",
+});
+
+const client = new Client({ name: "freshcontext-smoke", version: "0.0.0" });
+
+try {
+  await client.connect(transport);
+
+  const serverVersion = client.getServerVersion();
+  assert(serverVersion?.version === pkg.version, `serverInfo.version ${serverVersion?.version} !== package.json ${pkg.version}`);
+
+  const tools = await client.listTools();
+  const names = tools.tools.map((tool) => tool.name).sort();
+  assert(names.length === 21, `Expected 21 tools, got ${names.length}: ${names.join(", ")}`);
+  assert(names.includes("extract_hackernews"), "Missing extract_hackernews");
+  assert(names.includes("extract_finance"), "Missing extract_finance");
+
+  const hnText = textOf(await client.callTool({
+    name: "extract_hackernews",
+    arguments: { url: "browser agents", max_length: 2000 },
+  }));
+  assert(!/Invalid URL|Expected string to match URL/i.test(hnText), "HN text query failed URL validation");
+  assert(/\[FRESHCONTEXT\]/.test(hnText), "HN text query missing FreshContext envelope");
+  parseFreshContextJson(hnText);
+
+  const hnUrl = textOf(await client.callTool({
+    name: "extract_hackernews",
+    arguments: { url: "https://news.ycombinator.com/news", max_length: 2000 },
+  }));
+  const hnJson = parseFreshContextJson(hnUrl);
+  const hnDate = hnJson.freshcontext.content_date;
+  if (hnDate) {
+    assert(!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\s+\d+/.test(hnDate), "HN date contains malformed ISO + epoch suffix");
+    assert(!Number.isNaN(new Date(hnDate).getTime()), `HN date is not valid ISO: ${hnDate}`);
+    assert(typeof hnJson.freshcontext.freshness_score === "number", "HN dated result should have numeric freshness_score");
+  }
+
+  const finance = textOf(await client.callTool({
+    name: "extract_finance",
+    arguments: { url: "MSFT", max_length: 2000 },
+  }));
+  assert(!/Yahoo Finance API error|query1\.finance|401/.test(finance), "Finance still exposes Yahoo 401 path");
+  assert(/source:\s*stooq/i.test(finance), "Finance output missing source: stooq");
+  assertNoMisleadingFailureEnvelope(finance, "finance MSFT");
+  parseFreshContextJson(finance);
+
+  const financeFailure = textOf(await client.callTool({
+    name: "extract_finance",
+    arguments: { url: "NO_SUCH_TICKER_123456789", max_length: 2000 },
+  }));
+  assertNoMisleadingFailureEnvelope(financeFailure, "finance failure");
+
+  console.log(JSON.stringify({
+    ok: true,
+    package_version: pkg.version,
+    server_version: serverVersion.version,
+    tool_count: names.length,
+  }, null, 2));
+} finally {
+  await client.close();
+}

--- a/server.json
+++ b/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/PrinceGabriel-lgtm/freshcontext-mcp",
     "source": "github"
   },
-  "version": "0.3.16",
+  "version": "0.3.17",
   "website_url": "https://freshcontext-site.pages.dev",
   "packages": [
     {
       "registry_type": "npm",
       "registry_base_url": "https://registry.npmjs.org",
       "identifier": "freshcontext-mcp",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "transport": {
         "type": "stdio"
       }

--- a/src/adapters/finance.ts
+++ b/src/adapters/finance.ts
@@ -1,159 +1,139 @@
 import { AdapterResult, ExtractOptions } from "../types.js";
 
 /**
- * Finance adapter — Yahoo Finance public API, no auth required.
+ * Finance adapter — no-key Stooq quote feed.
  * Accepts:
- *   - A ticker symbol e.g. "AAPL" or "MSFT,GOOG"
- *   - A company name e.g. "Apple" (will search for ticker first)
+ *   - A ticker symbol e.g. "AAPL" or "MSFT"
  *   - Comma-separated tickers for comparison
+ *
+ * Stooq provides quote/OHLC/volume data, not fundamentals. FreshContext should
+ * only stamp observations it actually received.
  */
 
-interface YahooQuote {
+interface StooqQuote {
   symbol: string;
-  shortName?: string;
-  longName?: string;
-  regularMarketPrice?: number;
-  regularMarketChange?: number;
-  regularMarketChangePercent?: number;
-  marketCap?: number;
-  regularMarketVolume?: number;
-  fiftyTwoWeekHigh?: number;
-  fiftyTwoWeekLow?: number;
-  trailingPE?: number;
-  dividendYield?: number;
-  currency?: string;
-  exchangeName?: string;
-  regularMarketTime?: number;
-  longBusinessSummary?: string;
-  sector?: string;
-  industry?: string;
-  fullTimeEmployees?: number;
-  website?: string;
+  date: string;
+  time: string;
+  open: number | string;
+  high: number | string;
+  low: number | string;
+  close: number | string;
+  volume: number | string;
 }
 
-function formatMarketCap(cap: number | undefined): string {
-  if (!cap) return "N/A";
-  if (cap >= 1e12) return `$${(cap / 1e12).toFixed(2)}T`;
-  if (cap >= 1e9) return `$${(cap / 1e9).toFixed(2)}B`;
-  if (cap >= 1e6) return `$${(cap / 1e6).toFixed(2)}M`;
-  return `$${cap.toLocaleString()}`;
+interface ParsedQuote {
+  requested: string;
+  stooqSymbol: string;
+  quote: StooqQuote;
+  timestamp: string;
 }
 
-function formatChange(change: number | undefined, pct: number | undefined): string {
-  if (change === undefined || pct === undefined) return "N/A";
-  const sign = change >= 0 ? "+" : "";
-  return `${sign}${change.toFixed(2)} (${sign}${pct.toFixed(2)}%)`;
+function toStooqSymbol(ticker: string): string {
+  const clean = ticker.trim().toUpperCase().replace(/[^A-Z0-9.^=-]/g, "");
+  if (!clean) throw new Error("Ticker cannot be empty");
+  if (clean.includes(".") || clean.startsWith("^") || clean.includes("=")) return clean;
+  return `${clean}.US`;
+}
+
+function toNumber(value: number | string | undefined): number | null {
+  if (value === undefined || value === "N/D") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizeQuoteTimestamp(date: string, time: string): string {
+  if (!date || date === "N/D") throw new Error("Quote date unavailable");
+  const clock = time && time !== "N/D" ? time : "00:00:00";
+  const parsed = new Date(`${date}T${clock}Z`);
+  if (Number.isNaN(parsed.getTime())) throw new Error(`Invalid quote timestamp: ${date} ${time}`);
+  return parsed.toISOString();
+}
+
+function formatNumber(value: number | string | undefined, prefix = ""): string {
+  const n = toNumber(value);
+  return n === null ? "N/A" : `${prefix}${n.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+}
+
+async function fetchStooqQuote(ticker: string): Promise<ParsedQuote> {
+  const stooqSymbol = toStooqSymbol(ticker);
+  const url = `https://stooq.com/q/l/?s=${encodeURIComponent(stooqSymbol.toLowerCase())}&f=sd2t2ohlcv&h&e=json`;
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": "freshcontext-mcp/0.3.17",
+      "Accept": "application/json",
+    },
+  });
+  if (!res.ok) throw new Error(`Stooq quote API error: ${res.status}`);
+
+  const data = await res.json() as { symbols?: StooqQuote[] };
+  const quote = data.symbols?.[0];
+  if (!quote) throw new Error(`No quote returned for ${ticker}`);
+  if (quote.close === "N/D" || quote.date === "N/D") {
+    throw new Error(`No Stooq quote data found for ${ticker}`);
+  }
+
+  return {
+    requested: ticker,
+    stooqSymbol,
+    quote,
+    timestamp: normalizeQuoteTimestamp(quote.date, quote.time),
+  };
+}
+
+function formatQuote(result: ParsedQuote): string {
+  const q = result.quote;
+  return [
+    `${result.requested.toUpperCase()} — ${q.symbol}`,
+    `source: stooq`,
+    `Quote timestamp: ${result.timestamp}`,
+    "",
+    `Close:  ${formatNumber(q.close, "$")}`,
+    `Open:   ${formatNumber(q.open, "$")}`,
+    `High:   ${formatNumber(q.high, "$")}`,
+    `Low:    ${formatNumber(q.low, "$")}`,
+    `Volume: ${formatNumber(q.volume)}`,
+  ].join("\n");
 }
 
 export async function financeAdapter(options: ExtractOptions): Promise<AdapterResult> {
   const input = options.url.trim();
-
-  // Support comma-separated tickers
   const rawTickers = input
     .split(",")
-    .map((t) => t.trim().toUpperCase())
+    .map((t) => t.trim())
     .filter(Boolean)
-    .slice(0, 5); // max 5 at once
+    .slice(0, 5);
 
-  const results: string[] = [];
-  let latestTimestamp: number | null = null;
+  if (!rawTickers.length) throw new Error("At least one ticker is required");
+
+  const successes: ParsedQuote[] = [];
+  const failures: string[] = [];
 
   for (const ticker of rawTickers) {
     try {
-      const quoteData = await fetchQuote(ticker);
-      if (quoteData) {
-        results.push(formatQuote(quoteData));
-        if (quoteData.regularMarketTime) {
-          latestTimestamp = Math.max(latestTimestamp ?? 0, quoteData.regularMarketTime);
-        }
-      }
+      successes.push(await fetchStooqQuote(ticker));
     } catch (err) {
-      results.push(`[${ticker}] Error: ${err instanceof Error ? err.message : String(err)}`);
+      failures.push(`[${ticker.toUpperCase()}] ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  const raw = results.join("\n\n─────────────────────────────\n\n").slice(0, options.maxLength ?? 5000);
-  const content_date = latestTimestamp
-    ? new Date(latestTimestamp * 1000).toISOString()
-    : new Date().toISOString();
+  if (!successes.length) {
+    throw new Error(`Finance quote lookup failed for all tickers via source=stooq. ${failures.join("; ")}`);
+  }
 
-  return { raw, content_date, freshness_confidence: "high" };
-}
+  const sections = successes.map(formatQuote);
+  if (failures.length) {
+    sections.push(["Partial failures:", ...failures.map((f) => `- ${f}`)].join("\n"));
+  }
 
-async function fetchQuote(ticker: string): Promise<YahooQuote | null> {
-  // v7 quote endpoint — public, no auth
-  const quoteUrl = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(ticker)}&fields=shortName,longName,regularMarketPrice,regularMarketChange,regularMarketChangePercent,marketCap,regularMarketVolume,fiftyTwoWeekHigh,fiftyTwoWeekLow,trailingPE,dividendYield,currency,exchangeName,regularMarketTime`;
+  const raw = sections.join("\n\n-----------------------------\n\n").slice(0, options.maxLength ?? 5000);
+  const content_date = successes
+    .map((s) => s.timestamp)
+    .sort()
+    .reverse()[0] ?? null;
 
-  const quoteRes = await fetch(quoteUrl, {
-    headers: {
-      "User-Agent": "Mozilla/5.0 (compatible; freshcontext-mcp/0.1.5)",
-      "Accept": "application/json",
-    },
-  });
-
-  if (!quoteRes.ok) throw new Error(`Yahoo Finance API error: ${quoteRes.status}`);
-
-  const quoteJson = await quoteRes.json() as {
-    quoteResponse?: { result?: YahooQuote[] };
+  return {
+    raw,
+    content_date,
+    freshness_confidence: failures.length ? "medium" : "high",
   };
-
-  const quote = quoteJson?.quoteResponse?.result?.[0];
-  if (!quote) throw new Error(`No data found for ticker: ${ticker}`);
-
-  // Optionally fetch company summary (v11 quoteSummary)
-  try {
-    const summaryUrl = `https://query1.finance.yahoo.com/v11/finance/quoteSummary/${encodeURIComponent(ticker)}?modules=assetProfile`;
-    const summaryRes = await fetch(summaryUrl, {
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; freshcontext-mcp/0.1.5)" },
-    });
-    if (summaryRes.ok) {
-      const summaryJson = await summaryRes.json() as {
-        quoteSummary?: { result?: Array<{ assetProfile?: YahooQuote }> };
-      };
-      const profile = summaryJson?.quoteSummary?.result?.[0]?.assetProfile;
-      if (profile) {
-        Object.assign(quote, {
-          longBusinessSummary: profile.longBusinessSummary,
-          sector: profile.sector,
-          industry: profile.industry,
-          fullTimeEmployees: profile.fullTimeEmployees,
-          website: profile.website,
-        });
-      }
-    }
-  } catch {
-    // Summary is optional — continue without it
-  }
-
-  return quote;
-}
-
-function formatQuote(q: YahooQuote): string {
-  const lines = [
-    `${q.symbol} — ${q.longName ?? q.shortName ?? "Unknown"}`,
-    `Exchange: ${q.exchangeName ?? "N/A"} · Currency: ${q.currency ?? "USD"}`,
-    "",
-    `Price:       ${q.regularMarketPrice !== undefined ? `$${q.regularMarketPrice.toFixed(2)}` : "N/A"}`,
-    `Change:      ${formatChange(q.regularMarketChange, q.regularMarketChangePercent)}`,
-    `Market Cap:  ${formatMarketCap(q.marketCap)}`,
-    `Volume:      ${q.regularMarketVolume?.toLocaleString() ?? "N/A"}`,
-    `52w High:    ${q.fiftyTwoWeekHigh !== undefined ? `$${q.fiftyTwoWeekHigh.toFixed(2)}` : "N/A"}`,
-    `52w Low:     ${q.fiftyTwoWeekLow !== undefined ? `$${q.fiftyTwoWeekLow.toFixed(2)}` : "N/A"}`,
-    `P/E Ratio:   ${q.trailingPE !== undefined ? q.trailingPE.toFixed(2) : "N/A"}`,
-    `Div Yield:   ${q.dividendYield !== undefined ? `${(q.dividendYield * 100).toFixed(2)}%` : "N/A"}`,
-  ];
-
-  if (q.sector || q.industry) {
-    lines.push("");
-    if (q.sector) lines.push(`Sector:      ${q.sector}`);
-    if (q.industry) lines.push(`Industry:    ${q.industry}`);
-    if (q.fullTimeEmployees) lines.push(`Employees:   ${q.fullTimeEmployees.toLocaleString()}`);
-    if (q.website) lines.push(`Website:     ${q.website}`);
-  }
-
-  if (q.longBusinessSummary) {
-    lines.push("", "About:", q.longBusinessSummary.slice(0, 500) + (q.longBusinessSummary.length > 500 ? "…" : ""));
-  }
-
-  return lines.join("\n");
 }

--- a/src/adapters/gdelt.ts
+++ b/src/adapters/gdelt.ts
@@ -14,7 +14,7 @@ import { AdapterResult, ExtractOptions } from "../types.js";
 
 const HEADERS = {
   "Accept": "application/json",
-  "User-Agent": "freshcontext-mcp/0.3.16 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
+  "User-Agent": "freshcontext-mcp/0.3.17 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
 };
 
 interface GdeltArticle {

--- a/src/adapters/gebiz.ts
+++ b/src/adapters/gebiz.ts
@@ -24,7 +24,7 @@ const BASE_URL = "https://data.gov.sg/api/action/datastore_search";
 
 const HEADERS = {
   "Accept": "application/json",
-  "User-Agent": "freshcontext-mcp/0.3.16 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
+  "User-Agent": "freshcontext-mcp/0.3.17 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
 };
 
 interface GeBIZRecord {

--- a/src/adapters/hackernews.ts
+++ b/src/adapters/hackernews.ts
@@ -2,10 +2,29 @@ import { chromium } from "playwright";
 import { AdapterResult, ExtractOptions } from "../types.js";
 import { validateUrl } from "../security.js";
 
+function isUrl(input: string): boolean {
+  try {
+    new URL(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeHnDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const match = raw.match(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/);
+  if (!match) return null;
+  const isoLike = match[0].endsWith("Z") ? match[0] : `${match[0]}Z`;
+  const parsed = new Date(isoLike);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
 export async function hackerNewsAdapter(options: ExtractOptions): Promise<AdapterResult> {
-  // Validate URL — allow both HN and Algolia domains
-  validateUrl(options.url, "hackernews");
-  const url = options.url;
+  const input = options.url.trim();
+  if (!input) throw new Error("HN URL or search query is required");
+
+  const url = isUrl(input) ? validateUrl(input, "hackernews") : `hn-search:${input}`;
 
   if (url.includes("hn.algolia.com/api/") || url.startsWith("hn-search:")) {
     const query = url.startsWith("hn-search:")
@@ -36,17 +55,21 @@ export async function hackerNewsAdapter(options: ExtractOptions): Promise<Adapte
           `[${i + 1}] ${r.title ?? "Untitled"}`,
           `URL: ${r.url ?? `https://news.ycombinator.com/item?id=${r.objectID}`}`,
           `Score: ${r.points} points | ${r.num_comments} comments`,
-          `Author: ${r.author} | Posted: ${r.created_at}`,
+          `Author: ${r.author} | Posted: ${normalizeHnDate(r.created_at) ?? r.created_at}`,
         ].join("\n")
       )
       .join("\n\n")
       .slice(0, options.maxLength ?? 4000);
 
-    const newest = data.hits.map((r) => r.created_at).sort().reverse()[0] ?? null;
+    const newest = data.hits
+      .map((r) => normalizeHnDate(r.created_at))
+      .filter((d): d is string => Boolean(d))
+      .sort()
+      .reverse()[0] ?? null;
+
     return { raw, content_date: newest, freshness_confidence: newest ? "high" : "medium" };
   }
 
-  // Default: browser-based scrape for HN front page or search pages
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
 
@@ -75,17 +98,22 @@ export async function hackerNewsAdapter(options: ExtractOptions): Promise<Adapte
   const typedData = data as Array<{ title: string | null; link: string | null; score: string | null; age: string | null; commentLink: string | null }>;
 
   const raw = typedData
-    .map((r, i) =>
-      [
+    .map((r, i) => {
+      const date = normalizeHnDate(r.age);
+      return [
         `[${i + 1}] ${r.title ?? "Untitled"}`,
         `URL: ${r.link ?? "N/A"}`,
         `Score: ${r.score ?? "N/A"} | ${r.commentLink ?? ""}`,
-        `Posted: ${r.age ?? "unknown"}`,
-      ].join("\n")
-    )
+        `Posted: ${date ?? "unknown"}`,
+      ].join("\n");
+    })
     .join("\n\n");
 
-  const newestDate = typedData.map((r) => r.age).filter(Boolean).sort().reverse()[0] ?? null;
+  const newestDate = typedData
+    .map((r) => normalizeHnDate(r.age))
+    .filter((d): d is string => Boolean(d))
+    .sort()
+    .reverse()[0] ?? null;
 
   return {
     raw,

--- a/src/adapters/repoSearch.ts
+++ b/src/adapters/repoSearch.ts
@@ -25,7 +25,7 @@ export async function repoSearchAdapter(options: ExtractOptions): Promise<Adapte
   const res = await fetch(apiUrl, {
     headers: {
       Accept: "application/vnd.github.v3+json",
-      "User-Agent": "freshcontext-mcp/0.3.16 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
+      "User-Agent": "freshcontext-mcp/0.3.17 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
     },
   });
 

--- a/src/adapters/secFilings.ts
+++ b/src/adapters/secFilings.ts
@@ -15,7 +15,7 @@ import { AdapterResult, ExtractOptions } from "../types.js";
 
 const HEADERS = {
   "Accept": "application/json",
-  "User-Agent": "freshcontext-mcp/0.3.16 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
+  "User-Agent": "freshcontext-mcp/0.3.17 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)",
 };
 
 interface SecFiling {

--- a/src/security.ts
+++ b/src/security.ts
@@ -13,7 +13,7 @@ export const ALLOWED_DOMAINS: Record<string, string[]> = {
   repoSearch: [],    // uses GitHub API directly, no browser
   packageTrends: [], // uses npm/PyPI APIs directly, no browser
   reddit: [],        // uses public Reddit JSON API, no browser
-  finance: [],       // uses Yahoo Finance API, no browser
+  finance: [],       // uses Stooq quote API, no browser
   productHunt: ["www.producthunt.com", "producthunt.com"],
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import { SecurityError, formatSecurityError } from "./security.js";
 
 const server = new McpServer({
   name: "freshcontext-mcp",
-  version: "0.3.16",
+  version: "0.3.17",
 });
 
 // ─── Tool: extract_github ────────────────────────────────────────────────────
@@ -77,9 +77,9 @@ server.registerTool(
   "extract_hackernews",
   {
     description:
-      "Extract top stories or search results from Hacker News. Real-time dev/tech community sentiment with post timestamps.",
+      "Extract top stories or search results from Hacker News. Accepts an HN/Algolia URL or a plain search query while preserving the url field for compatibility.",
     inputSchema: z.object({
-      url: z.string().url().describe("HN URL e.g. https://news.ycombinator.com or https://hn.algolia.com/?q=..."),
+      url: z.string().min(1).describe("HN URL e.g. https://news.ycombinator.com/news, Algolia API URL, or search query e.g. 'browser agents'"),
       max_length: z.number().optional().default(4000),
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
@@ -192,7 +192,7 @@ server.registerTool(
   "extract_finance",
   {
     description:
-      "Live stock data via Yahoo Finance — price, change, market cap, P/E, 52w range, sector, business summary. Accepts up to 5 comma-separated tickers. Returns timestamped freshcontext.",
+      "No-key stock quote data via Stooq — close, open, high, low, volume, quote timestamp, and source. Accepts up to 5 comma-separated tickers. Returns timestamped freshcontext only for successful observations.",
     inputSchema: z.object({
       url: z.string().describe("Ticker symbol(s) e.g. 'AAPL' or 'MSFT,GOOG,PLTR'"),
       max_length: z.number().optional().default(5000),
@@ -466,7 +466,7 @@ server.registerTool(
   "extract_finance_landscape",
   {
     description:
-      "Composite financial intelligence tool for developers. Given one or more ticker symbols, simultaneously queries: (1) Yahoo Finance for live price/market data, (2) Hacker News for developer community sentiment, (3) Reddit for investor and tech community discussion, (4) GitHub for repo ecosystem activity around the company's tech, and (5) their product changelog for release velocity as a company health signal. Answers: What's the price? What are developers saying? Is the company actually shipping? Returns a unified 5-source timestamped report. Bloomberg Terminal doesn't give you this.",
+      "Composite financial intelligence tool for developers. Given one or more ticker symbols, simultaneously queries: (1) Stooq for no-key quote data, (2) Hacker News for developer community sentiment, (3) Reddit for investor and tech community discussion, (4) GitHub for repo ecosystem activity around the company's tech, and (5) their product changelog for release velocity as a company health signal. Answers: What's the price? What are developers saying? Is the company actually shipping? Returns a unified 5-source timestamped report.",
     inputSchema: z.object({
       tickers: z.string().describe(
         "One or more ticker symbols e.g. 'PLTR' or 'PLTR,MSFT,GOOG'. Up to 5 tickers."
@@ -501,10 +501,10 @@ server.registerTool(
     const combined = [
       `# Finance + Developer Intelligence: "${tickers}"${company_name ? ` (${company_name})` : ""}`,
       `Generated: ${new Date().toISOString()}`,
-      `Sources: Yahoo Finance · Hacker News · Reddit · GitHub · Changelog`,
+      `Sources: Stooq · Hacker News · Reddit · GitHub · Changelog`,
       min_freshness_score ? `min_freshness_score: ${min_freshness_score}` : null,
       "",
-      sectionWithFreshnessCheck("📈 Market Data (Yahoo Finance)", priceResult, "finance", min_freshness_score),
+      sectionWithFreshnessCheck("📈 Market Data (Stooq)", priceResult, "finance", min_freshness_score),
       sectionWithFreshnessCheck("💬 Developer Sentiment (Hacker News)", hnResult, "hackernews", min_freshness_score),
       sectionWithFreshnessCheck("🗣️ Community Discussion (Reddit)", redditResult, "reddit", min_freshness_score),
       sectionWithFreshnessCheck("📦 Repo Ecosystem (GitHub)", repoResult, "reposearch", min_freshness_score),
@@ -578,7 +578,7 @@ server.registerTool(
   "extract_company_landscape",
   {
     description:
-      "Composite company intelligence tool. The most complete single-call company analysis available. Simultaneously queries 5 unique sources: (1) SEC EDGAR for 8-K material event filings — what the company legally just disclosed, (2) USASpending.gov for federal contract footprint — who is giving them government money, (3) GDELT for global news intelligence — what the world is saying about them right now, (4) their product changelog — are they actually shipping, (5) Yahoo Finance — what the market is pricing in. Returns a unified 5-source timestamped report. Unique: this combination is not available in any other MCP server.",
+      "Composite company intelligence tool. The most complete single-call company analysis available. Simultaneously queries 5 unique sources: (1) SEC EDGAR for 8-K material event filings — what the company legally just disclosed, (2) USASpending.gov for federal contract footprint — who is giving them government money, (3) GDELT for global news intelligence — what the world is saying about them right now, (4) their product changelog — are they actually shipping, (5) Stooq quote data — what the market is pricing in. Returns a unified 5-source timestamped report. Unique: this combination is not available in any other MCP server.",
     inputSchema: z.object({
       company: z.string().describe(
         "Company name e.g. 'Palantir', 'Anthropic', 'OpenAI'"
@@ -609,14 +609,14 @@ server.registerTool(
     const combined = [
       `# Company Intelligence Landscape: "${company}"${ticker ? ` (${ticker})` : ""}`,
       `Generated: ${new Date().toISOString()}`,
-      `Sources: SEC EDGAR · USASpending.gov · GDELT · Changelog · Yahoo Finance`,
+      `Sources: SEC EDGAR · USASpending.gov · GDELT · Changelog · Stooq`,
       min_freshness_score ? `min_freshness_score: ${min_freshness_score}` : null,
       "",
       sectionWithFreshnessCheck("📋 SEC 8-K Filings — Legal Disclosures", secResult, "sec_filings", min_freshness_score),
       sectionWithFreshnessCheck("🏛️ Federal Contract Awards (USASpending.gov)", contractsResult, "govcontracts", min_freshness_score),
       sectionWithFreshnessCheck("🌍 Global News Intelligence (GDELT)", gdeltResult, "gdelt", min_freshness_score),
       sectionWithFreshnessCheck("🔄 Product Release Velocity (Changelog)", changelogResult, "changelog", min_freshness_score),
-      sectionWithFreshnessCheck("📈 Market Data (Yahoo Finance)", financeResult, "finance", min_freshness_score),
+      sectionWithFreshnessCheck("📈 Market Data (Stooq)", financeResult, "finance", min_freshness_score),
     ].filter(Boolean).join("\n\n");
 
     return { content: [{ type: "text", text: combined }] };
@@ -723,6 +723,4 @@ async function main() {
 }
 
 main().catch(console.error);
-
-
 

--- a/src/tools/freshnessStamp.ts
+++ b/src/tools/freshnessStamp.ts
@@ -61,6 +61,24 @@ function scoreLabel(score: number | null): string {
   return "use with caution";
 }
 
+function looksLikeFailedAdapterContent(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return true;
+  if (/^\[(?:error|security)\]/i.test(trimmed)) return true;
+  if (/^(?:error|failed|upstream|timeout)\b/i.test(trimmed)) return true;
+
+  const meaningful = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!meaningful.length) return true;
+
+  const failureLines = meaningful.filter((line) =>
+    /\b(?:error|failed|failure|timeout|401|403|404|429|5\d\d)\b/i.test(line)
+  );
+  return failureLines.length === meaningful.length;
+}
+
 // ─── Main stamp function ──────────────────────────────────────────────────────
 export function stampFreshness(
   result: AdapterResult,
@@ -68,8 +86,11 @@ export function stampFreshness(
   adapter: string
 ): FreshContext {
   const retrieved_at = new Date().toISOString();
+  const failedContent = looksLikeFailedAdapterContent(result.raw);
+  const content_date = failedContent ? null : result.content_date;
+  const freshness_confidence = failedContent ? "low" : result.freshness_confidence;
   const freshness_score = calculateFreshnessScore(
-    result.content_date,
+    content_date,
     retrieved_at,
     adapter
   );
@@ -77,9 +98,9 @@ export function stampFreshness(
   return {
     content: result.raw.slice(0, options.maxLength ?? 8000),
     source_url: options.url,
-    content_date: result.content_date,
+    content_date,
     retrieved_at,
-    freshness_confidence: result.freshness_confidence,
+    freshness_confidence,
     freshness_score,
     adapter,
   };

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshcontext-mcp-worker",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshcontext-mcp-worker",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.0.4",
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshcontext-mcp-worker",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": true,
   "scripts": {
     "dev": "wrangler dev",

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { synthesizeBriefing as generateAIBriefing } from "./synthesize.js";
 import { scoreSignal, parseStoredProfile, semanticFingerprint, isDuplicate, applyDecay, RT_EXPIRY_FLOOR, calculateFreshnessScore, freshnessLabel } from "./intelligence.js";
 
-const SERVICE_VERSION = "0.3.16";
+const SERVICE_VERSION = "0.3.17";
 const SERVICE_UA = `freshcontext-mcp/${SERVICE_VERSION} (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)`;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -334,6 +334,19 @@ function errResponse(message: string, status: number): Response {
   });
 }
 
+function looksLikeFailedAdapterContent(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return true;
+  if (/^\[(?:error|security)\]/i.test(trimmed)) return true;
+  if (/^(?:error|failed|upstream|timeout)\b/i.test(trimmed)) return true;
+  const meaningful = trimmed.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  if (!meaningful.length) return true;
+  const failureLines = meaningful.filter(line =>
+    /\b(?:error|failed|failure|timeout|401|403|404|429|5\d\d)\b/i.test(line)
+  );
+  return failureLines.length === meaningful.length;
+}
+
 function stamp(
   content: string,
   url: string,
@@ -342,7 +355,10 @@ function stamp(
   adapter: string
 ): string {
   const retrieved_at = new Date().toISOString();
-  const freshness_score = calculateFreshnessScore(date, retrieved_at, adapter);
+  const failedContent = looksLikeFailedAdapterContent(content);
+  const safeDate = failedContent ? null : date;
+  const safeConfidence = failedContent ? "low" : confidence;
+  const freshness_score = calculateFreshnessScore(safeDate, retrieved_at, adapter);
   const sliced = content.slice(0, 6000);
 
   const scoreLine = freshness_score !== null
@@ -352,9 +368,9 @@ function stamp(
   const textEnvelope = [
     "[FRESHCONTEXT]",
     `Source: ${url}`,
-    `Published: ${date ?? "unknown"}`,
+    `Published: ${safeDate ?? "unknown"}`,
     `Retrieved: ${retrieved_at}`,
-    `Confidence: ${confidence}`,
+    `Confidence: ${safeConfidence}`,
     scoreLine,
     "---",
     sliced,
@@ -364,9 +380,9 @@ function stamp(
   const structured = {
     freshcontext: {
       source_url:           url,
-      content_date:         date,
+      content_date:         safeDate,
       retrieved_at,
-      freshness_confidence: confidence,
+      freshness_confidence: safeConfidence,
       freshness_score,
       adapter,
     },
@@ -432,6 +448,59 @@ function formatUSD(amount: number | null | undefined): string {
   if (abs >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
   if (abs >= 1_000) return `$${(amount / 1_000).toFixed(1)}K`;
   return `$${amount.toFixed(0)}`;
+}
+
+function normalizeHnDate(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const match = raw.match(/\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\b/);
+  if (!match) return null;
+  const isoLike = match[0].endsWith("Z") ? match[0] : `${match[0]}Z`;
+  const parsed = new Date(isoLike);
+  return isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+interface StooqQuote {
+  symbol: string;
+  date: string;
+  time: string;
+  open: number | string;
+  high: number | string;
+  low: number | string;
+  close: number | string;
+  volume: number | string;
+}
+
+interface ParsedFinanceQuote {
+  requested: string;
+  stooqSymbol: string;
+  quote: StooqQuote;
+  timestamp: string;
+}
+
+function toStooqSymbol(ticker: string): string {
+  const clean = ticker.trim().toUpperCase().replace(/[^A-Z0-9.^=-]/g, "");
+  if (!clean) throw new Error("Ticker cannot be empty");
+  if (clean.includes(".") || clean.startsWith("^") || clean.includes("=")) return clean;
+  return `${clean}.US`;
+}
+
+function quoteNumber(value: number | string | undefined): number | null {
+  if (value === undefined || value === "N/D") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function normalizeQuoteTimestamp(date: string, time: string): string {
+  if (!date || date === "N/D") throw new Error("Quote date unavailable");
+  const clock = time && time !== "N/D" ? time : "00:00:00";
+  const parsed = new Date(`${date}T${clock}Z`);
+  if (isNaN(parsed.getTime())) throw new Error(`Invalid quote timestamp: ${date} ${time}`);
+  return parsed.toISOString();
+}
+
+function formatQuoteValue(value: number | string | undefined, prefix = ""): string {
+  const n = quoteNumber(value);
+  return n === null ? "N/A" : `${prefix}${n.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
 }
 
 // ── arXiv (HTTP, Atom XML) ───────────────────────────────────────────────────
@@ -783,9 +852,9 @@ async function fetchHN(query: string, maxLength: number, log: LogFields = {}): P
   const json = await res.json() as { hits: Array<{ title: string; url: string | null; points: number; num_comments: number; author: string; created_at: string; objectID: string }> };
   if (!json.hits.length) return { raw: `No HN stories for "${query}".`, date: null, conf: "low" };
   const raw = json.hits.map((r, i) =>
-    `[${i + 1}] ${r.title}\nURL: ${r.url ?? `https://news.ycombinator.com/item?id=${r.objectID}`}\nScore: ${r.points} | ${r.num_comments} comments\nAuthor: ${r.author} | Posted: ${r.created_at}`
+    `[${i + 1}] ${r.title}\nURL: ${r.url ?? `https://news.ycombinator.com/item?id=${r.objectID}`}\nScore: ${r.points} | ${r.num_comments} comments\nAuthor: ${r.author} | Posted: ${normalizeHnDate(r.created_at) ?? r.created_at}`
   ).join("\n\n").slice(0, maxLength);
-  const newest = json.hits.map(r => r.created_at).sort().reverse()[0] ?? null;
+  const newest = json.hits.map(r => normalizeHnDate(r.created_at)).filter((d): d is string => Boolean(d)).sort().reverse()[0] ?? null;
   return { raw, date: newest, conf: newest ? "high" : "medium" };
 }
 
@@ -829,42 +898,54 @@ async function fetchReddit(query: string, maxLength: number, log: LogFields = {}
   return { raw, date, conf: date ? "high" : "medium" };
 }
 
-// ── Yahoo Finance — composite helper ─────────────────────────────────────────
+// ── Finance quotes (Stooq, no key) — composite helper ────────────────────────
 async function fetchFinance(tickers: string, maxLength: number, log: LogFields = {}): Promise<AdapterHit> {
-  const list = tickers.split(",").map(t => t.trim().toUpperCase()).filter(Boolean).slice(0, 5);
-  const out: string[] = [];
-  let latestTs: number | null = null;
+  const list = tickers.split(",").map(t => t.trim()).filter(Boolean).slice(0, 5);
+  if (!list.length) throw new Error("At least one ticker is required");
+  const successes: ParsedFinanceQuote[] = [];
+  const failures: string[] = [];
   for (const t of list) {
     try {
+      const stooqSymbol = toStooqSymbol(t);
       const res = await sourceFetch(
-        `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(t)}&fields=shortName,longName,regularMarketPrice,regularMarketChange,regularMarketChangePercent,marketCap,regularMarketVolume,fiftyTwoWeekHigh,fiftyTwoWeekLow,trailingPE,dividendYield,currency,exchangeName,regularMarketTime`,
-        { headers: { "User-Agent": `Mozilla/5.0 (compatible; freshcontext-mcp/${SERVICE_VERSION})` } },
+        `https://stooq.com/q/l/?s=${encodeURIComponent(stooqSymbol.toLowerCase())}&f=sd2t2ohlcv&h&e=json`,
+        { headers: { "User-Agent": SERVICE_UA, "Accept": "application/json" } },
         { ...log, adapter: "finance" }
       );
-      if (!res.ok) { out.push(`[${t}] Error ${res.status}`); continue; }
-      const j = await res.json() as { quoteResponse?: { result?: Array<Record<string, number | string>> } };
-      const q = j?.quoteResponse?.result?.[0];
-      if (!q) { out.push(`[${t}] No data`); continue; }
-      if (typeof q.regularMarketTime === "number") latestTs = Math.max(latestTs ?? 0, q.regularMarketTime);
-      const sign = (typeof q.regularMarketChange === "number" && q.regularMarketChange >= 0) ? "+" : "";
-      const cap = typeof q.marketCap === "number"
-        ? (q.marketCap >= 1e12 ? `$${(q.marketCap/1e12).toFixed(2)}T` : q.marketCap >= 1e9 ? `$${(q.marketCap/1e9).toFixed(2)}B` : `$${q.marketCap.toLocaleString()}`)
-        : "N/A";
-      const price = typeof q.regularMarketPrice === "number" ? `$${q.regularMarketPrice.toFixed(2)}` : "N/A";
-      const chg = typeof q.regularMarketChange === "number" && typeof q.regularMarketChangePercent === "number"
-        ? `${sign}${q.regularMarketChange.toFixed(2)} (${sign}${q.regularMarketChangePercent.toFixed(2)}%)` : "N/A";
-      out.push([
-        `${q.symbol} — ${q.longName ?? q.shortName ?? "Unknown"}`,
-        `Price: ${price}  Change: ${chg}  Cap: ${cap}`,
-        `P/E: ${typeof q.trailingPE === "number" ? q.trailingPE.toFixed(2) : "N/A"}  Vol: ${typeof q.regularMarketVolume === "number" ? q.regularMarketVolume.toLocaleString() : "N/A"}`,
-      ].join("\n"));
+      if (!res.ok) throw new Error(`Stooq quote API error: ${res.status}`);
+      const json = await res.json() as { symbols?: StooqQuote[] };
+      const quote = json.symbols?.[0];
+      if (!quote || quote.close === "N/D" || quote.date === "N/D") throw new Error(`No Stooq quote data found for ${t}`);
+      successes.push({
+        requested: t,
+        stooqSymbol,
+        quote,
+        timestamp: normalizeQuoteTimestamp(quote.date, quote.time),
+      });
     } catch (e: unknown) {
-      out.push(`[${t}] Error: ${e instanceof Error ? e.message : String(e)}`);
+      failures.push(`[${t.toUpperCase()}] ${e instanceof Error ? e.message : String(e)}`);
     }
   }
+
+  if (!successes.length) {
+    throw new Error(`Finance quote lookup failed for all tickers via source=stooq. ${failures.join("; ")}`);
+  }
+
+  const out = successes.map(({ requested, quote, timestamp }) => [
+    `${requested.toUpperCase()} — ${quote.symbol}`,
+    `source: stooq`,
+    `Quote timestamp: ${timestamp}`,
+    "",
+    `Close:  ${formatQuoteValue(quote.close, "$")}`,
+    `Open:   ${formatQuoteValue(quote.open, "$")}`,
+    `High:   ${formatQuoteValue(quote.high, "$")}`,
+    `Low:    ${formatQuoteValue(quote.low, "$")}`,
+    `Volume: ${formatQuoteValue(quote.volume)}`,
+  ].join("\n"));
+  if (failures.length) out.push(["Partial failures:", ...failures.map(f => `- ${f}`)].join("\n"));
   const raw = out.join("\n\n─────────────\n\n").slice(0, maxLength);
-  const date = latestTs ? new Date(latestTs * 1000).toISOString() : new Date().toISOString();
-  return { raw, date, conf: "high" };
+  const date = successes.map(s => s.timestamp).sort().reverse()[0] ?? null;
+  return { raw, date, conf: failures.length ? "medium" : "high" };
 }
 
 // ── YC companies (yc-oss feed) — composite helper ────────────────────────────
@@ -1037,32 +1118,32 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
   });
 
   server.registerTool("extract_hackernews", {
-    description: "Extract top stories or search results from Hacker News with real-time timestamps.",
-    inputSchema: z.object({ url: z.string().url().describe("HN URL e.g. https://news.ycombinator.com or https://hn.algolia.com/?q=...") }),
+    description: "Extract top stories or search results from Hacker News. The url field accepts an HN/Algolia URL or a plain search query.",
+    inputSchema: z.object({ url: z.string().min(1).describe("HN URL e.g. https://news.ycombinator.com/news, Algolia API URL, or search query e.g. 'browser agents'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
     return withCache("hackernews", url, env.CACHE, async () => {
       try {
-        if (url.includes("hn.algolia.com")) {
+        let parsedInput: URL | null = null;
+        try { parsedInput = new URL(url); } catch { parsedInput = null; }
+        if (!parsedInput || url.includes("hn.algolia.com")) {
           let apiUrl: string;
-          if (url.includes("/api/")) {
+          if (parsedInput && url.includes("/api/")) {
             apiUrl = url;
           } else {
             // Extract ?q= or ?query= param if present — don't encode the whole URL as the query
             let searchTerm: string;
-            try {
-              const parsed = new URL(url);
-              searchTerm = parsed.searchParams.get("q") ?? parsed.searchParams.get("query") ?? "";
-            } catch { searchTerm = ""; }
+            if (parsedInput) searchTerm = parsedInput.searchParams.get("q") ?? parsedInput.searchParams.get("query") ?? "";
+            else searchTerm = url.trim();
             apiUrl = `https://hn.algolia.com/api/v1/search?query=${encodeURIComponent(searchTerm)}&tags=story&hitsPerPage=20`;
           }
           const res = await sourceFetch(apiUrl, undefined, adapterLog("extract_hackernews", "hackernews", url));
           if (!res.ok) throw new Error(`HN API error: ${res.status}`);
           const json = await res.json() as any;
           const raw = json.hits.map((r: any, i: number) =>
-            `[${i+1}] ${r.title}\nURL: ${r.url ?? `https://news.ycombinator.com/item?id=${r.objectID}`}\nScore: ${r.points} | ${r.num_comments} comments\nPosted: ${r.created_at}`
+            `[${i+1}] ${r.title}\nURL: ${r.url ?? `https://news.ycombinator.com/item?id=${r.objectID}`}\nScore: ${r.points} | ${r.num_comments} comments\nPosted: ${normalizeHnDate(r.created_at) ?? r.created_at}`
           ).join("\n\n");
-          const newest = json.hits.map((r: any) => r.created_at).sort().reverse()[0] ?? null;
+          const newest = json.hits.map((r: any) => normalizeHnDate(r.created_at)).filter(Boolean).sort().reverse()[0] ?? null;
           return ok(stamp(raw, url, newest, newest ? "high" : "medium", "hackernews"));
         }
         const safeUrl = validateUrl(url, "hackernews");
@@ -1079,8 +1160,8 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
         })()`);
         await browser.close();
         const items = data as any[];
-        const raw = items.map((r, i) => `[${i+1}] ${r.title}\nURL: ${r.link}\nScore: ${r.score ?? "N/A"}\nPosted: ${r.age ?? "unknown"}`).join("\n\n");
-        const newest2 = items.map(r => r.age).filter(Boolean).sort().reverse()[0] ?? null;
+        const raw = items.map((r, i) => `[${i+1}] ${r.title}\nURL: ${r.link}\nScore: ${r.score ?? "N/A"}\nPosted: ${normalizeHnDate(r.age) ?? "unknown"}`).join("\n\n");
+        const newest2 = items.map(r => normalizeHnDate(r.age)).filter(Boolean).sort().reverse()[0] ?? null;
         return ok(stamp(raw, safeUrl, newest2, newest2 ? "high" : "medium", "hackernews"));
       } catch (err: unknown) { return adapterError("extract_hackernews", "hackernews", url, err); }
     });
@@ -1261,33 +1342,14 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
   });
 
   server.registerTool("extract_finance", {
-    description: "Live stock data via Yahoo Finance. Accepts comma-separated ticker symbols.",
+    description: "No-key stock quote data via Stooq. Accepts comma-separated ticker symbols and returns quote/OHLC/volume observations with timestamps.",
     inputSchema: z.object({ url: z.string().describe("Ticker symbol(s) e.g. 'AAPL' or 'MSFT,GOOG'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
     return withCache("finance", url, env.CACHE, async () => {
       try {
-        const tickers = url.split(",").map(t => t.trim().toUpperCase()).filter(Boolean).slice(0, 5);
-        const results: string[] = [];
-        let latestTs: number | null = null;
-        for (const ticker of tickers) {
-          const res = await sourceFetch(
-            `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${ticker}&fields=shortName,longName,regularMarketPrice,regularMarketChange,regularMarketChangePercent,marketCap,regularMarketVolume,fiftyTwoWeekHigh,fiftyTwoWeekLow,trailingPE,dividendYield,currency,exchangeName,regularMarketTime`,
-            { headers: { "User-Agent": `Mozilla/5.0 (compatible; freshcontext-mcp/${SERVICE_VERSION})` } },
-            adapterLog("extract_finance", "finance", url)
-          );
-          if (!res.ok) { results.push(`[${ticker}] Error: ${res.status}`); continue; }
-          const json = await res.json() as any;
-          const q = json?.quoteResponse?.result?.[0];
-          if (!q) { results.push(`[${ticker}] No data found`); continue; }
-          if (q.regularMarketTime) latestTs = Math.max(latestTs ?? 0, q.regularMarketTime);
-          const sign = (q.regularMarketChange ?? 0) >= 0 ? "+" : "";
-          const cap = q.marketCap >= 1e12 ? `$${(q.marketCap/1e12).toFixed(2)}T` : q.marketCap >= 1e9 ? `$${(q.marketCap/1e9).toFixed(2)}B` : "N/A";
-          results.push([`${q.symbol} — ${q.longName ?? q.shortName ?? "Unknown"}`, `Price: $${q.regularMarketPrice?.toFixed(2) ?? "N/A"}`, `Change: ${sign}${q.regularMarketChange?.toFixed(2) ?? "N/A"} (${sign}${q.regularMarketChangePercent?.toFixed(2) ?? "N/A"}%)`, `Market Cap: ${cap}`, `P/E: ${q.trailingPE?.toFixed(2) ?? "N/A"}`].join("\n"));
-        }
-        const raw = results.join("\n\n─────────────────────────────\n\n");
-        const date = latestTs ? new Date(latestTs * 1000).toISOString() : new Date().toISOString();
-        return ok(stamp(raw, `yahoo-finance:${tickers.join(",")}`, date, "high", "finance"));
+        const r = await fetchFinance(url, 5000, adapterLog("extract_finance", "finance", url));
+        return ok(stamp(r.raw, `stooq:${url}`, r.date, r.conf, "finance"));
       } catch (err: unknown) { return adapterError("extract_finance", "finance", url, err); }
     });
   });
@@ -1517,7 +1579,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
 
   // ─── Tool: extract_finance_landscape ────────────────────────────────────
   server.registerTool("extract_finance_landscape", {
-    description: "Composite financial intelligence: Yahoo Finance market data + HN sentiment + Reddit discussion + GitHub ecosystem + product changelog. 5-source unified report.",
+    description: "Composite financial intelligence: Stooq quote data + HN sentiment + Reddit discussion + GitHub ecosystem + product changelog. 5-source unified report.",
     inputSchema: z.object({
       tickers: z.string().describe("One or more ticker symbols e.g. 'PLTR' or 'PLTR,MSFT'"),
       company_name: z.string().optional().describe("Company name for HN/Reddit/GitHub searches"),
@@ -1544,9 +1606,9 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
       const body = [
         `# Finance + Developer Intelligence: "${tickers}"${company_name ? ` (${company_name})` : ""}`,
         `Generated: ${new Date().toISOString()}`,
-        `Sources: Yahoo Finance · Hacker News · Reddit · GitHub · Changelog`,
+        `Sources: Stooq · Hacker News · Reddit · GitHub · Changelog`,
         "",
-        section("📈 Market Data (Yahoo Finance)", price),
+        section("📈 Market Data (Stooq)", price),
         section("💬 Developer Sentiment (Hacker News)", hn),
         section("🗣️ Community Discussion (Reddit)", reddit),
         section("📦 Repo Ecosystem (GitHub)", repos),
@@ -1558,7 +1620,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
 
   // ─── Tool: extract_company_landscape ────────────────────────────────────
   server.registerTool("extract_company_landscape", {
-    description: "Most complete single-call company intelligence: SEC 8-K filings + USASpending federal contracts + GDELT global news + product changelog + Yahoo Finance. 5 unique sources.",
+    description: "Most complete single-call company intelligence: SEC 8-K filings + USASpending federal contracts + GDELT global news + product changelog + Stooq quote data. 5 unique sources.",
     inputSchema: z.object({
       company: z.string().describe("Company name e.g. 'Palantir', 'Anthropic'"),
       ticker: z.string().optional().describe("Stock ticker for finance data"),
@@ -1584,13 +1646,13 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
       const body = [
         `# Company Intelligence Landscape: "${company}"${ticker ? ` (${ticker})` : ""}`,
         `Generated: ${new Date().toISOString()}`,
-        `Sources: SEC EDGAR · USASpending.gov · GDELT · Changelog · Yahoo Finance`,
+        `Sources: SEC EDGAR · USASpending.gov · GDELT · Changelog · Stooq`,
         "",
         section("📋 SEC 8-K Filings — Legal Disclosures", sec),
         section("🏛️ Federal Contract Awards", contracts),
         section("🌍 Global News Intelligence (GDELT)", gdelt),
         section("🔄 Product Release Velocity (Changelog)", changelog),
-        section("📈 Market Data (Yahoo Finance)", finance),
+        section("📈 Market Data (Stooq)", finance),
       ].join("\n\n");
       return ok(stamp(body, `company_landscape:${company}`, new Date().toISOString(), "high", "company_landscape"));
     });
@@ -1695,12 +1757,8 @@ async function runAdapter(adapter: string, query: string, filters: Record<string
       return sanitize(`Stars:${data.stargazers_count} Forks:${data.forks_count} Updated:${data.updated_at} Issues:${data.open_issues_count} Lang:${data.language ?? "N/A"} Description:${data.description ?? ""}`);
     }
     case "finance": {
-      const symbol = query.replace(/[^A-Z0-9=^.-]/gi, "");
-      const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${symbol}&fields=regularMarketPrice,regularMarketTime,shortName`;
-      const res = await sourceFetch(url, { headers: { "User-Agent": "freshcontext-mcp/cron" } }, { ...log, adapter: "finance" });
-      const data = await res.json() as any;
-      const q = data.quoteResponse?.result?.[0];
-      return q ? `${symbol}: $${q.regularMarketPrice} | ${q.shortName} | ${new Date(q.regularMarketTime * 1000).toISOString()}` : `No price data for ${symbol}`;
+      const r = await fetchFinance(query, 1200, { ...log, adapter: "finance" });
+      return sanitize(r.raw);
     }
     case "reddit": {
       const sub = query.match(/r\/(\w+)/)?.[1];


### PR DESCRIPTION
## Summary
- replace broken Yahoo finance quote paths with Stooq no-key quote observations
- prevent all-upstream-failure content from being stamped as high-confidence fresh intelligence
- allow `extract_hackernews.url` to accept plain search text as well as HN/Algolia URLs
- normalize HN scrape dates to valid ISO strings before freshness scoring
- align package, Worker, registry metadata, and stdio serverInfo on 0.3.17
- add stdio smoke coverage for version/tool count/HN/finance regressions

## Verification
- npm run build
- cd worker && npx tsc --noEmit
- npm run smoke:stdio
- stale-string search: NO_STALE_HITS
- npm pack --dry-run: freshcontext-mcp@0.3.17, 26 files, clean dist package

## Release boundaries
- no site changes
- no feed worker changes
- no Worker deploy in this PR
- no npm publish in this PR