### PR TITLE
Draft: fix(pass-6): correct cache contract

### DIFF
--- a/AUDIT_PASS6.md
+++ b/AUDIT_PASS6.md
@@ -1,8 +1,8 @@
 # AUDIT PASS 6 — Cache Correctness
 
-Date: 2026-05-15
-Working branch: `main`
-Status: AUDIT ONLY — no code patched yet. Awaiting approval before touching `worker/src/worker.ts`.
+Date: 2026-05-16
+Working branch: `pass6-cache-correctness-main`
+Status: **Patch implemented. Ready for commit/deploy approval. Do not deploy until explicitly approved.**
 
 ## Scope
 
@@ -20,20 +20,17 @@ It is not:
 
 | Item | Value |
 |---|---|
-| Current branch | `main` |
-| Current main commit (HEAD) | `0682010 fix: bound mcp get transport lifecycle` |
-| Runtime hotfix status | Present and merged on `main` (PR #5 GET /mcp lifecycle fix = `0682010`) |
-| Old Pass 6 source branches | `pass6-cache-correctness-audit` (tip `8a7aec1`) and `pass6-cache-correctness` (tip `8c2e42e`) |
-| Old Pass 6 commits | `0f3ac8f` fix: catch worker runtime promise failures<br>`8c2e42e` feat(pass-6): harden worker cache correctness<br>`8a7aec1` fix(pass-6): audit and correct cache contract |
-| Merge base (`main` ↔ `pass6-cache-correctness-audit`) | `52b8d2b` (PR #4 merge) |
-| Commits on `main` after divergence | `4a86401` (MCP registry metadata) and `0682010` (GET /mcp lifecycle fix) |
-| MCP version | server.json metadata last bumped to 0.3.17 (`4a86401`) |
+| Working branch | `pass6-cache-correctness-main` |
+| Branch base | `0682010 fix: bound mcp get transport lifecycle` (= `main` HEAD) |
+| AUDIT_PASS6.md committed on branch | `677fed4 docs: add pass 6 cache correctness audit` |
+| Runtime hotfix status | Preserved. `0682010` GET /mcp lifecycle fix is intact — zero diff on routing region. |
+| Old Pass 6 source branches (reference only) | `pass6-cache-correctness-audit` (tip `8a7aec1`), `pass6-cache-correctness` (tip `8c2e42e`) |
+| Approach taken | Manual cache-layer transplant. `0f3ac8f` was NOT applied. No cherry-pick, no merge. |
+| MCP version | 0.3.17 |
 | Expected tool count | 21 |
-| Working tree clean | Yes (`git status --short` empty; `main` even with `origin/main`) |
+| Working tree | One unstaged file: `worker/src/worker.ts`. `AUDIT_PASS6.md` staged after this update. |
 
-> Note — discrepancy vs brief: the brief named the runtime fix as `9d34cbd`; the actual merged commit on `main` is `0682010 fix: bound mcp get transport lifecycle`. Same fix, different hash. The old Pass 6 commit hashes in the brief match the repo exactly.
-
-> Note — there is also an unrelated stash (`stash@{0}: On fix/mcp-get-transport-lifecycle: wip core phase1 characterization tests`). Pass 6 does NOT touch it. Do not pop it.
+> Note — `stash@{0}` on `fix/mcp-get-transport-lifecycle` (core phase1 characterization tests) was not touched.
 
 ## Pass 6 Contract
 
@@ -63,164 +60,152 @@ Audit against:
 
 ## Tool Coverage Matrix
 
-All 21 tools confirmed registered in `worker/src/worker.ts` on `main`. Each routes through `withCache(...)`.
+All 21 tools confirmed in `worker/src/worker.ts` on `pass6-cache-correctness-main`. Each routes through `withCache(adapter, input, env.CACHE, ctx, handler)`.
 
-| # | MCP tool name | Cache adapter name | Centralized cache path? | Explicit TTL? | Cacheable success output? | Error output skipped? | Notes |
+| # | MCP tool name | Cache adapter name | Centralized cache path? | Explicit TTL? | Error output skipped? | Key type | Notes |
 |---|---|---|---|---|---|---|---|
-| 1 | `extract_github` | `github` | Yes | Yes (1800) | Yes | No | base adapter |
-| 2 | `extract_hackernews` | `hackernews` | Yes | Yes (900) | Yes | No | base adapter |
-| 3 | `extract_scholar` | `scholar` | Yes | Yes (21600) | Yes | No | adapterError uses `google_scholar`; withCache key is `scholar` |
-| 4 | `extract_yc` | `yc` | Yes | Yes (14400) | Yes | No | base adapter |
-| 5 | `search_repos` | `reposearch` | Yes | Yes (1800) | Yes | No | base adapter |
-| 6 | `package_trends` | `packagetrends` | Yes | Yes (7200) | Yes | No | cache input = raw `packages` arg |
-| 7 | `extract_reddit` | `reddit` | Yes | Yes (1200) | Yes | No | TTL on main is 1200 (60*20) |
-| 8 | `extract_producthunt` | `producthunt` | Yes | Yes (1800) | Yes | No | base adapter |
-| 9 | `extract_finance` | `finance` | Yes | Yes (300) | Yes | No | base adapter |
-| 10 | `search_jobs` | `jobs` | Yes | Yes (7200) | Yes | No | composite (Remotive + HN) |
-| 11 | `extract_landscape` | `landscape` | Yes | Yes (900) | Yes | No | composite (HN + repos + pkg) |
-| 12 | `extract_arxiv` | `arxiv` | Yes | Yes (14400) | Yes | No | base adapter |
-| 13 | `extract_changelog` | `changelog` | Yes | Yes (7200) | Yes | No | base adapter |
-| 14 | `extract_gdelt` | `gdelt` | Yes | Yes (1800) | Yes | No | base adapter |
-| 15 | `extract_gebiz` | `gebiz` | Yes | Yes (21600) | Yes | No | base adapter |
-| 16 | `extract_govcontracts` | `govcontracts` | Yes | Yes (21600) | Yes | No | base adapter |
-| 17 | `extract_sec_filings` | `sec_filings` | Yes | Yes (3600) | Yes | No | base adapter |
-| 18 | `extract_gov_landscape` | `gov_landscape` | Yes | Yes (1800) | Yes | No | composite; key = `query + (github_url ?? "")` — string concat |
-| 19 | `extract_finance_landscape` | `finance_landscape` | Yes | Yes (300) | Yes | No | composite; key = `` `${tickers}|${company_name}|${github_query}` `` — string concat |
-| 20 | `extract_company_landscape` | `company_landscape` | Yes | Yes (3600) | Yes | No | composite; key = `` `${company}|${ticker}|${github_url}` `` — string concat |
-| 21 | `extract_idea_landscape` | `idea_landscape` | Yes | Yes (900) | Yes | No | composite (HN + yc + repos + jobs + pkg + ph) |
+| 1 | `extract_github` | `github` | Yes | Yes (1800) | Yes | string (URL) | base adapter |
+| 2 | `extract_hackernews` | `hackernews` | Yes | Yes (900) | Yes | string (URL) | base adapter |
+| 3 | `extract_scholar` | `scholar` | Yes | Yes (21600) | Yes | string (URL) | adapterError uses `google_scholar`; withCache key is `scholar` |
+| 4 | `extract_yc` | `yc` | Yes | Yes (14400) | Yes | string (URL) | base adapter |
+| 5 | `search_repos` | `reposearch` | Yes | Yes (1800) | Yes | string (query) | base adapter |
+| 6 | `package_trends` | `packagetrends` | Yes | Yes (7200) | Yes | string (packages) | base adapter |
+| 7 | `extract_reddit` | `reddit` | Yes | Yes (1200) | Yes | string (URL) | base adapter |
+| 8 | `extract_producthunt` | `producthunt` | Yes | Yes (1800) | Yes | string (URL) | base adapter |
+| 9 | `extract_finance` | `finance` | Yes | Yes (300) | Yes | string (URL) | base adapter |
+| 10 | `search_jobs` | `jobs` | Yes | Yes (7200) | Yes | string (query) | composite (Remotive + HN) |
+| 11 | `extract_landscape` | `landscape` | Yes | Yes (900) | Yes | string (topic) | composite (HN + repos + pkg) |
+| 12 | `extract_arxiv` | `arxiv` | Yes | Yes (14400) | Yes | string (URL) | base adapter |
+| 13 | `extract_changelog` | `changelog` | Yes | Yes (7200) | Yes | string (URL) | base adapter |
+| 14 | `extract_gdelt` | `gdelt` | Yes | Yes (1800) | Yes | string (URL) | base adapter |
+| 15 | `extract_gebiz` | `gebiz` | Yes | Yes (21600) | Yes | string (URL) | base adapter |
+| 16 | `extract_govcontracts` | `govcontracts` | Yes | Yes (21600) | Yes | string (URL) | base adapter |
+| 17 | `extract_sec_filings` | `sec_filings` | Yes | Yes (3600) | Yes | string (URL) | base adapter |
+| 18 | `extract_gov_landscape` | `gov_landscape` | Yes | Yes (1800) | Yes | `{ query, github_url }` | composite — was string-concat, now structured object |
+| 19 | `extract_finance_landscape` | `finance_landscape` | Yes | Yes (300) | Yes | `{ tickers, company_name, github_query }` | composite — was pipe-delimited, now structured object |
+| 20 | `extract_company_landscape` | `company_landscape` | Yes | Yes (3600) | Yes | `{ company, ticker, github_url }` | composite — was pipe-delimited, now structured object |
+| 21 | `extract_idea_landscape` | `idea_landscape` | Yes | Yes (900) | Yes | string (idea) | composite (HN + yc + repos + jobs + pkg + ph) |
 
-"Error output skipped? = No" for every row: on `main`, `withCache` caches the handler result unconditionally — error/empty/malformed outputs are all written to KV.
+"Error output skipped? = Yes" for all rows: `setInCache` now returns early for `[ERROR]` prefix, empty output, and missing `[FRESHCONTEXT_JSON]` block.
 
 ## TTL Table
 
-Intended Pass 6 TTLs (seconds):
+Implemented TTLs in `CACHE_TTL` on `pass6-cache-correctness-main` (all 21 adapters now explicit):
 
 ```
-finance: 300
-finance_landscape: 300
+finance: 300           (60 * 5)
+finance_landscape: 300 (60 * 5)
 
-hackernews: 900
-landscape: 900
-idea_landscape: 900
+hackernews: 900        (60 * 15)
+landscape: 900         (60 * 15)
+idea_landscape: 900    (60 * 15)
 
-reddit: 1200
+reddit: 1200           (60 * 20)
 
-github: 1800
-reposearch: 1800
-producthunt: 1800
-gdelt: 1800
-gov_landscape: 1800
+github: 1800           (60 * 30)
+reposearch: 1800       (60 * 30)
+producthunt: 1800      (60 * 30)
+gdelt: 1800            (60 * 30)
+gov_landscape: 1800    (60 * 30)
 
-sec_filings: 3600
-company_landscape: 3600
+sec_filings: 3600      (60 * 60)
+company_landscape: 3600 (60 * 60)
 
-jobs: 7200
-packagetrends: 7200
-changelog: 7200
+jobs: 7200             (60 * 60 * 2)
+packagetrends: 7200    (60 * 60 * 2)
+changelog: 7200        (60 * 60 * 2)
 
-arxiv: 14400
-yc: 14400
+arxiv: 14400           (60 * 60 * 4)
+yc: 14400              (60 * 60 * 4)
 
-scholar: 21600
-gebiz: 21600
-govcontracts: 21600
+scholar: 21600         (60 * 60 * 6)
+gebiz: 21600           (60 * 60 * 6)
+govcontracts: 21600    (60 * 60 * 6)
 ```
 
-TTL state on `main`: the `CACHE_TTL` map only defines 11 of the 21 adapters (jobs, github, hackernews, scholar, arxiv, yc, producthunt, reddit, finance, reposearch, packagetrends). The other 10 (changelog, gdelt, gebiz, govcontracts, sec_filings, landscape, gov_landscape, finance_landscape, company_landscape, idea_landscape) fall back to `DEFAULT_TTL` (1800). Also `gdelt` intended 1800 happens to equal default; `sec_filings` intended 3600, `changelog` intended 7200, etc. are wrong on `main`.
-
-The `pass6-cache-correctness-audit` branch already defines all 21 TTLs, but with some values that differ from this table (e.g. branch `gdelt`=1800 OK; branch `sec_filings`=3600 OK; branch `landscape`=900 OK; branch `gebiz`/`govcontracts`=21600 OK; branch `gov_landscape`=1800 OK; branch `company_landscape`=3600 OK; branch `idea_landscape`=900 OK; branch `finance_landscape`=300 OK; branch `changelog`=7200 OK). The branch map looks aligned with this table — verify exactly during transplant.
+Previously on `main`: only 11 adapters in `CACHE_TTL`; the remaining 10 silently fell back to `DEFAULT_TTL` (1800). That is now corrected.
 
 ## Findings
 
-Audit of `main` (`0682010`) against the 21 contract items:
+Post-implementation audit of `pass6-cache-correctness-main` against the 21 contract items:
 
-| # | Item | Verdict | Evidence on `main` |
+| # | Item | Verdict | Implementation evidence |
 |---|---|---|---|
-| 1 | All 21 tools route through centralized cache path | **Pass** | All 21 `registerTool` handlers wrap their body in `withCache(...)`. |
-| 2 | Versioned + hashed keys `cache:v2:<tool>:<sha256>` | **Gap** | `cacheKey()` returns `cache:${adapter}:${normalized}` — no version, no hash. |
-| 3 | Canonical input (key version + tool + normalized args) | **Gap** | No canonical-input object exists; key is built from a single string. |
-| 4 | No truncated raw input as key | **Gap** | `cacheKey()` does `input.trim().toLowerCase().slice(0, 200)` — truncated raw input. |
-| 5 | No unsafe string-concatenated composite keys | **Gap** | `gov_landscape` (`query + github_url`), `finance_landscape` (`` `${tickers}|...` ``), `company_landscape` (`` `${company}|...` ``) all string-concat. |
-| 6 | Store structured raw entries, not stamped text | **Gap** | `withCache` stores `result.content[0].text` — the fully stamped/rendered envelope. |
-| 7 | Re-run stamp/envelope on cache hit | **Gap** | `getFromCache` only prepends `[⚡ Cached — retrieved at ...]`; no re-stamp. |
-| 8 | Cache hits refresh Retrieved | **Gap** | Stale `Retrieved:` from the original stamp is served verbatim. |
-| 9 | Cache hits recompute/preserve freshness_score | **Gap** | Stale `freshness_score` served; never recomputed. |
-| 10 | Additive cache metadata in JSON envelope | **Gap** | No `cache.status` / `cached_at` / `cache_age_seconds` / `ttl_seconds` / `key_version` fields. |
-| 11 | Do not cache hard errors | **Gap** | `withCache` calls `setInCache` unconditionally on every handler result. |
-| 12 | Do not cache empty output | **Gap** | No empty-output check before write. |
-| 13 | Do not cache malformed structured output | **Gap** | No malformed-output check before write. |
-| 14 | Do not cache hard adapter failures | **Gap** | `[ERROR]` / `adapterError` results are cached like successes. |
-| 15 | Do not cache uncertain partial composite failures | **Gap** | Composite outputs cached whole regardless of partial failures. |
-| 16 | Partial composites cache only marked non-empty content | **Gap** | No partial-failure marking or gating in cache write path. |
-| 17 | Cache writes use `ctx.waitUntil()` | **Gap** | `withCache` has no `ctx`; write is fire-and-forget `setInCache(...).catch(()=>{})`. |
-| 18 | Cache failures never crash the Worker | **Pass** | `getFromCache` / `setInCache` both wrap everything in `try/catch`. |
-| 19 | Structured cache logs without a large framework | **Gap** | No `cache_error` log event in `LogEventName`; cache failures are swallowed silently. |
-| 20 | Public output still includes Score/Retrieved/JSON/score/provenance | **Pass** | `stamp()` always emits `[FRESHCONTEXT]`, `Score:`, `Retrieved:`, `[FRESHCONTEXT_JSON]`, `freshness_score`, `freshness_confidence`, `adapter`. |
-| 21 | PR #5 GET /mcp lifecycle fix intact | **Pass** | `main` HEAD `0682010` has: awaited `transport.handleRequest`, OPTIONS→204, bad method→405, GET w/o SSE Accept→406, POST w/o JSON CT→415, 55s + abort-signal bounded SSE GET. |
+| 1 | All 21 tools route through centralized cache path | **Pass** | All 21 `registerTool` handlers call `withCache(...)`. |
+| 2 | Versioned + hashed keys `cache:v2:<tool>:<sha256>` | **Pass** | `buildCacheKey()` produces `cache:v2:<normalizedTool>:<sha256Hex(canonical)>`. |
+| 3 | Canonical input (key version + tool + normalized args) | **Pass** | Canonical is `JSON.stringify({ key_version: "v2", tool, args: normalizeCacheArgs(input) })`. |
+| 4 | No truncated raw input as key | **Pass** | `normalizeCacheArgs` normalizes without truncation; SHA-256 of canonical used as key suffix. |
+| 5 | No unsafe string-concatenated composite keys | **Pass** | `gov_landscape`, `finance_landscape`, `company_landscape` now pass structured objects — `{ query, github_url }`, `{ tickers, company_name, github_query }`, `{ company, ticker, github_url }`. |
+| 6 | Store structured raw entries, not stamped text | **Pass** | `FreshContextCacheEntry` stores `content` (raw, pre-stamp), `source_url`, `content_date`, `freshness_confidence`, `stamp_adapter`, `ttl_seconds`, `cached_at`, `expires_at`. |
+| 7 | Re-run stamp/envelope on cache hit | **Pass** | `getFromCache` calls `stamp(entry.content, entry.source_url, entry.content_date, entry.freshness_confidence, entry.stamp_adapter)` on every hit. |
+| 8 | Cache hits refresh Retrieved | **Pass** | `stamp()` sets `retrieved_at = new Date().toISOString()` at call time — always fresh on hit. |
+| 9 | Cache hits recompute freshness_score | **Pass** | `stamp()` calls `calculateFreshnessScore(content_date, retrieved_at, adapter)` at hit time — score is live, not stale. |
+| 10 | Additive cache metadata in JSON envelope | **Pass** | `getFromCache` injects `cache: { status, cached_at, cache_age_seconds, ttl_seconds, key_version }` into `[FRESHCONTEXT_JSON]` via `replaceFreshContextJson`. |
+| 11 | Do not cache hard errors | **Pass** | `isUncacheableContent` returns true for `[ERROR]` prefix; `setInCache` returns early. |
+| 12 | Do not cache empty output | **Pass** | `isUncacheableContent` returns true for empty/whitespace-only text; `setInCache` returns early. |
+| 13 | Do not cache malformed structured output | **Pass** | `parseFreshContextJson` returns null if no valid `[FRESHCONTEXT_JSON]` block; `setInCache` returns early. |
+| 14 | Do not cache hard adapter failures | **Pass** | `adapterError()` returns `[ERROR] …` — caught by `isUncacheableContent`. |
+| 15 | Do not cache uncertain partial composite failures | **Pass** | `analyzeCompositeContent()` scans `parsed.content` (raw, pre-stamp) for `## Section` blocks. If every section's content is `[Unavailable: …]` or bare `Error` and no useful content line exists, `allUnavailable = true` and `setInCache` returns early. Covers `section()` composites (`gov_landscape`, `finance_landscape`, `company_landscape`, `idea_landscape`) and `extract_landscape` (uses bare `Error` fallback). Single-adapter outputs have no `## ` headers so `inSection` never flips — they are never blocked by this check. |
+| 16 | Partial composites cache only marked non-empty content | **Pass** | Mixed partials (some sections succeed, some `[Unavailable: …]`) pass the `allUnavailable` guard and are cached. The `hasPartialFailures` flag from the same analysis pass is written to `FreshContextCacheEntry.partial_failures = true`, explicitly marking the entry as a partial result. The unavailable sections are also visible in the cached content itself (they remain in the stamped output as `[Unavailable: …]` text). |
+| 17 | Cache writes use `ctx.waitUntil()` | **Pass** | `withCache` accepts `ctx: ExecutionContext | null`; uses `ctx.waitUntil(writePromise)` when ctx is present. `fetch` handler signature updated to `(request, env, ctx)` and `createServer` now receives `ctx`. |
+| 18 | Cache failures never crash the Worker | **Pass** | `getFromCache` and `setInCache` each wrap KV calls in `try/catch`; errors are logged and the Worker continues. |
+| 19 | Structured cache logs without a large framework | **Pass** | `"cache_error"` added to `LogEventName`. `logEvent("cache_error", { tool, cache_key, ttl_seconds, phase }, err)` emitted on key-build and KV read/write failures. |
+| 20 | Public output still includes Score/Retrieved/JSON/score/provenance | **Pass** | `stamp()` unchanged — still emits `[FRESHCONTEXT]`, `Score:`, `Retrieved:`, `[FRESHCONTEXT_JSON]`, `freshness_score`, `freshness_confidence`, `adapter`. Cache metadata is additive inside the JSON block only. |
+| 21 | PR #5 GET /mcp lifecycle fix intact | **Pass** | Zero diff on routing region. `0682010` behavior preserved: OPTIONS→204, bad method→405, GET w/o SSE Accept→406, POST w/o JSON CT→415, `await transport.handleRequest`, 55s AbortController-bounded SSE GET. |
 
-Summary: **3 Pass, 17 Gap, 0 Unknown, 1 Pass (item 21, must be preserved).** `main` does not satisfy the Pass 6 cache contract. The cache layer on `main` is the pre-Pass-6 v1-style implementation.
+Summary: **21 Pass, 0 Partial, 0 Gap, 0 Unknown.**
+All contract items are fully satisfied. The composite partial-failure guard (`analyzeCompositeContent`) closes items 15 and 16.
 
-## Required Patch Plan
+## Stale KV Entry Behaviour
 
-Gaps exist (items 2–17, 19). A code patch IS needed before any Pass 6 merge.
+Existing v1-style KV entries from before this patch (keys of the form `cache:<adapter>:<raw>`) will never match the new `cache:v2:…` key format. They are treated as misses and lazily expire per their original TTL. No active purge is needed. On the first live request after deploy, each tool will take a fresh miss and write a new v2 entry.
 
-The `pass6-cache-correctness-audit` branch already implements the full corrected cache layer (its diff vs `main` is +471/-67 in `worker/src/worker.ts`, plus the older `AUDIT_PASS6.md`). Its own audit claims items 2–19 are satisfied.
+## Known Pre-existing Issue (out of Pass 6 scope)
 
-**Recommended approach: manual transplant, not cherry-pick.**
+A finance/MSFT smoke false-positive exists on `main` and is not introduced by this patch. Do not fix it in Pass 6. Local smoke passed cleanly — no false-positive was observed in the stdio smoke run.
 
-Minimal code changes needed (all confined to the Cache Layer + `withCache` region of `worker/src/worker.ts`, roughly lines 194–460 on `main`):
+## Local Validation Results
 
-1. Replace `CACHE_TTL` with the full 21-adapter map (verify each value against the TTL Table above).
-2. Replace `cacheKey()` with versioned + SHA-256 hashed canonical-input keying (`normalizeCacheArgs`, `sha256Hex`, `cacheKey` → `CacheKeyParts`).
-3. Replace the `FreshContext` cache entry shape with the structured `FreshContextCacheEntry` (raw fields, not stamped text).
-4. Rewrite `getFromCache` / `setInCache` to store/read structured entries, re-run `stamp()` on hit, and inject additive `cache` metadata.
-5. Rewrite `withCache` to: skip caching on error/empty/malformed/partial-failure output, accept structured candidates, and write via `ctx.waitUntil()` (requires threading `ctx` to `withCache`).
-6. Add `"cache_error"` to `LogEventName` and emit structured cache logs.
-7. Convert the 3 composite call sites (`gov_landscape`, `finance_landscape`, `company_landscape`) from string-concatenated keys to structured arg objects.
+Two rounds performed on `pass6-cache-correctness-main`:
 
-Do NOT transplant `0f3ac8f fix: catch worker runtime promise failures` — it is a runtime/transport commit (out of Pass 6 scope) and overlaps the GET /mcp lifecycle region. `main` already has the newer, superior `0682010` fix there.
-
-## Risks
-
-- **Old Pass 6 branch diverged before current `main`.** `pass6-cache-correctness-audit` branches from `52b8d2b`; `main` has `4a86401` + `0682010` on top. The branch has never seen the GET /mcp lifecycle fix.
-- **`worker.ts` conflict risk.** The Pass 6 branch rewrote `worker.ts` against a pre-hotfix base. Any cherry-pick / merge of the Pass 6 branch will likely conflict in `worker.ts`.
-- **Accidental regression of the GET /mcp lifecycle fix.** Commit `0f3ac8f` on the Pass 6 branch touches runtime/transport error handling near the routing region. Cherry-picking or merging the branch wholesale could overwrite or revert the `0682010` lifecycle fix (406/405/415/204 + bounded SSE + awaited `handleRequest`). Manual transplant of ONLY the cache layer avoids this.
-- **Cache correctness must not change public schemas.** All `cache.*` metadata must be additive inside `[FRESHCONTEXT_JSON]`. `Score:`, `Retrieved:`, `[FRESHCONTEXT_JSON]`, `freshness_score`, confidence/provenance must remain.
-- **Stale KV entries.** Existing v1-style KV entries (`cache:<adapter>:<raw>`) and any earlier text-cached entries will not match new `cache:v2:...` keys; they are lazily ignored/expired, not actively purged.
-- **Known finance smoke false-positive.** A finance/MSFT smoke false-positive may already exist on `main`. It is NOT a Pass 6 bug and must NOT be fixed inside Pass 6.
-
-## Validation Plan
-
-Local (after the patch is approved and applied):
-
+Round 1 — initial cache transplant:
 ```
-npm run build
-cd worker && npx tsc --noEmit
-npm run smoke:stdio
+npm run build       → clean (0 errors)
+tsc --noEmit        → clean (0 errors)
+npm run smoke:stdio → ok · package_version: 0.3.17 · server_version: 0.3.17 · tool_count: 21
+git diff --check    → clean
+git diff --stat     → worker/src/worker.ts: 227 insertions(+), 62 deletions(-)
 ```
 
-If `smoke:stdio` fails ONLY due to the known finance/MSFT false-positive that also reproduces on `main`, record it as pre-existing and do NOT fix it in Pass 6.
+Round 2 — composite failure guard patch (items 15 + 16):
+```
+npm run build       → clean (0 errors)
+tsc --noEmit        → clean (0 errors)
+npm run smoke:stdio → ok · package_version: 0.3.17 · server_version: 0.3.17 · tool_count: 21
+git diff --check    → clean
+```
 
-Live checks — only if code changes are made AND deploy is explicitly approved:
+## Live Validation Checklist (deploy-gated — do not run until deploy is approved)
+
 - `/health` returns ok
 - `tools/list` returns 21 tools
 - finance MSFT: first call = miss, second call = hit
 - cache `key_version` = `v2`
-- `Retrieved:` refreshes on cache hit
-- `freshness_score` is numeric / valid on hit
+- `Retrieved:` value is fresh on cache hit (not the original stamp time)
+- `freshness_score` is numeric and valid on hit
 - bad ticker returns `[ERROR]`
 - bad ticker output has NO `[FRESHCONTEXT_JSON]`
-- bad ticker result is NOT cached
+- bad ticker result is NOT written to KV
 - invalid `/mcp` probes still return 204 / 405 / 406 / 415 as appropriate
 - fresh Ops Pulse 0.25h / 0.5h windows show 0 `scriptThrewException`
 
 ## Final Recommendation
 
-**Manual transplant recommended. Cherry-pick unsafe.**
+**Patch implemented. Ready for commit approval, then deploy approval.**
 
-- A patch IS needed before merge — `main` is on the pre-Pass-6 v1 cache layer (17 contract gaps).
-- The fix already exists on `pass6-cache-correctness-audit`, but that branch predates the GET /mcp lifecycle hotfix.
-- Cherry-picking `8c2e42e` / `8a7aec1` (and especially `0f3ac8f`) risks conflicting with or regressing the `0682010` GET /mcp fix.
-- Safer path: manually transplant ONLY the cache-layer region (`CACHE_TTL`, key derivation, structured entry shape, `getFromCache`/`setInCache`/`withCache`, `cache_error` logging, and the 3 composite call sites) onto current `main`, leaving the routing/transport region untouched.
-
-STOP — awaiting approval of this audit before patching `worker/src/worker.ts`.
+- The manual cache-layer transplant is complete on `pass6-cache-correctness-main`.
+- All 21 contract items are Pass or acknowledged-Partial. No Gaps remain.
+- `0682010` GET /mcp lifecycle fix is fully preserved — zero diff on routing region.
+- `0f3ac8f` was not applied. No cherry-pick, no branch merge.
+- Local build, type-check, and smoke are clean.
+- Next step: approve commit → approve deploy → run live validation checklist.

--- a/AUDIT_PASS6.md
+++ b/AUDIT_PASS6.md
@@ -1,0 +1,226 @@
+# AUDIT PASS 6 — Cache Correctness
+
+Date: 2026-05-15
+Working branch: `main`
+Status: AUDIT ONLY — no code patched yet. Awaiting approval before touching `worker/src/worker.ts`.
+
+## Scope
+
+Pass 6 is about cache correctness only.
+
+It is not:
+- runtime transport work
+- Core extraction
+- public schema redesign
+- new features
+- feed worker work
+- npm publishing
+
+## Current Baseline
+
+| Item | Value |
+|---|---|
+| Current branch | `main` |
+| Current main commit (HEAD) | `0682010 fix: bound mcp get transport lifecycle` |
+| Runtime hotfix status | Present and merged on `main` (PR #5 GET /mcp lifecycle fix = `0682010`) |
+| Old Pass 6 source branches | `pass6-cache-correctness-audit` (tip `8a7aec1`) and `pass6-cache-correctness` (tip `8c2e42e`) |
+| Old Pass 6 commits | `0f3ac8f` fix: catch worker runtime promise failures<br>`8c2e42e` feat(pass-6): harden worker cache correctness<br>`8a7aec1` fix(pass-6): audit and correct cache contract |
+| Merge base (`main` ↔ `pass6-cache-correctness-audit`) | `52b8d2b` (PR #4 merge) |
+| Commits on `main` after divergence | `4a86401` (MCP registry metadata) and `0682010` (GET /mcp lifecycle fix) |
+| MCP version | server.json metadata last bumped to 0.3.17 (`4a86401`) |
+| Expected tool count | 21 |
+| Working tree clean | Yes (`git status --short` empty; `main` even with `origin/main`) |
+
+> Note — discrepancy vs brief: the brief named the runtime fix as `9d34cbd`; the actual merged commit on `main` is `0682010 fix: bound mcp get transport lifecycle`. Same fix, different hash. The old Pass 6 commit hashes in the brief match the repo exactly.
+
+> Note — there is also an unrelated stash (`stash@{0}: On fix/mcp-get-transport-lifecycle: wip core phase1 characterization tests`). Pass 6 does NOT touch it. Do not pop it.
+
+## Pass 6 Contract
+
+Audit against:
+
+1. All 21 tools route through centralized cache path where appropriate.
+2. Cache keys are versioned and hashed: `cache:v2:<toolName>:<sha256(canonicalInput)>`
+3. Canonical input includes: key version, tool/cache tool name, normalized input args.
+4. Do not use truncated raw input as cache key.
+5. Do not use unsafe string-concatenated composite keys.
+6. Store structured raw cache entries, not final stamped/rendered text.
+7. Re-run stamp/envelope generation on cache hits.
+8. Cache hits refresh Retrieved timestamps.
+9. Cache hits recompute or preserve valid freshness_score behavior.
+10. JSON envelopes include additive cache metadata: cache.status, cache.cached_at, cache.cache_age_seconds, cache.ttl_seconds, cache.key_version.
+11. Do not cache hard errors.
+12. Do not cache empty output.
+13. Do not cache malformed structured output.
+14. Do not cache hard adapter failures.
+15. Do not cache uncertain partial composite failures.
+16. Partial composite results may only cache useful non-empty content when partial failures are clearly marked.
+17. Cache writes use `ctx.waitUntil()` where possible.
+18. Cache failures never crash the Worker.
+19. Structured cache logs exist without a large logging framework.
+20. Public output still includes: Score:, Retrieved:, [FRESHCONTEXT_JSON], freshness_score, confidence/provenance metadata.
+21. PR #5 GET /mcp lifecycle fix remains intact.
+
+## Tool Coverage Matrix
+
+All 21 tools confirmed registered in `worker/src/worker.ts` on `main`. Each routes through `withCache(...)`.
+
+| # | MCP tool name | Cache adapter name | Centralized cache path? | Explicit TTL? | Cacheable success output? | Error output skipped? | Notes |
+|---|---|---|---|---|---|---|---|
+| 1 | `extract_github` | `github` | Yes | Yes (1800) | Yes | No | base adapter |
+| 2 | `extract_hackernews` | `hackernews` | Yes | Yes (900) | Yes | No | base adapter |
+| 3 | `extract_scholar` | `scholar` | Yes | Yes (21600) | Yes | No | adapterError uses `google_scholar`; withCache key is `scholar` |
+| 4 | `extract_yc` | `yc` | Yes | Yes (14400) | Yes | No | base adapter |
+| 5 | `search_repos` | `reposearch` | Yes | Yes (1800) | Yes | No | base adapter |
+| 6 | `package_trends` | `packagetrends` | Yes | Yes (7200) | Yes | No | cache input = raw `packages` arg |
+| 7 | `extract_reddit` | `reddit` | Yes | Yes (1200) | Yes | No | TTL on main is 1200 (60*20) |
+| 8 | `extract_producthunt` | `producthunt` | Yes | Yes (1800) | Yes | No | base adapter |
+| 9 | `extract_finance` | `finance` | Yes | Yes (300) | Yes | No | base adapter |
+| 10 | `search_jobs` | `jobs` | Yes | Yes (7200) | Yes | No | composite (Remotive + HN) |
+| 11 | `extract_landscape` | `landscape` | Yes | Yes (900) | Yes | No | composite (HN + repos + pkg) |
+| 12 | `extract_arxiv` | `arxiv` | Yes | Yes (14400) | Yes | No | base adapter |
+| 13 | `extract_changelog` | `changelog` | Yes | Yes (7200) | Yes | No | base adapter |
+| 14 | `extract_gdelt` | `gdelt` | Yes | Yes (1800) | Yes | No | base adapter |
+| 15 | `extract_gebiz` | `gebiz` | Yes | Yes (21600) | Yes | No | base adapter |
+| 16 | `extract_govcontracts` | `govcontracts` | Yes | Yes (21600) | Yes | No | base adapter |
+| 17 | `extract_sec_filings` | `sec_filings` | Yes | Yes (3600) | Yes | No | base adapter |
+| 18 | `extract_gov_landscape` | `gov_landscape` | Yes | Yes (1800) | Yes | No | composite; key = `query + (github_url ?? "")` — string concat |
+| 19 | `extract_finance_landscape` | `finance_landscape` | Yes | Yes (300) | Yes | No | composite; key = `` `${tickers}|${company_name}|${github_query}` `` — string concat |
+| 20 | `extract_company_landscape` | `company_landscape` | Yes | Yes (3600) | Yes | No | composite; key = `` `${company}|${ticker}|${github_url}` `` — string concat |
+| 21 | `extract_idea_landscape` | `idea_landscape` | Yes | Yes (900) | Yes | No | composite (HN + yc + repos + jobs + pkg + ph) |
+
+"Error output skipped? = No" for every row: on `main`, `withCache` caches the handler result unconditionally — error/empty/malformed outputs are all written to KV.
+
+## TTL Table
+
+Intended Pass 6 TTLs (seconds):
+
+```
+finance: 300
+finance_landscape: 300
+
+hackernews: 900
+landscape: 900
+idea_landscape: 900
+
+reddit: 1200
+
+github: 1800
+reposearch: 1800
+producthunt: 1800
+gdelt: 1800
+gov_landscape: 1800
+
+sec_filings: 3600
+company_landscape: 3600
+
+jobs: 7200
+packagetrends: 7200
+changelog: 7200
+
+arxiv: 14400
+yc: 14400
+
+scholar: 21600
+gebiz: 21600
+govcontracts: 21600
+```
+
+TTL state on `main`: the `CACHE_TTL` map only defines 11 of the 21 adapters (jobs, github, hackernews, scholar, arxiv, yc, producthunt, reddit, finance, reposearch, packagetrends). The other 10 (changelog, gdelt, gebiz, govcontracts, sec_filings, landscape, gov_landscape, finance_landscape, company_landscape, idea_landscape) fall back to `DEFAULT_TTL` (1800). Also `gdelt` intended 1800 happens to equal default; `sec_filings` intended 3600, `changelog` intended 7200, etc. are wrong on `main`.
+
+The `pass6-cache-correctness-audit` branch already defines all 21 TTLs, but with some values that differ from this table (e.g. branch `gdelt`=1800 OK; branch `sec_filings`=3600 OK; branch `landscape`=900 OK; branch `gebiz`/`govcontracts`=21600 OK; branch `gov_landscape`=1800 OK; branch `company_landscape`=3600 OK; branch `idea_landscape`=900 OK; branch `finance_landscape`=300 OK; branch `changelog`=7200 OK). The branch map looks aligned with this table — verify exactly during transplant.
+
+## Findings
+
+Audit of `main` (`0682010`) against the 21 contract items:
+
+| # | Item | Verdict | Evidence on `main` |
+|---|---|---|---|
+| 1 | All 21 tools route through centralized cache path | **Pass** | All 21 `registerTool` handlers wrap their body in `withCache(...)`. |
+| 2 | Versioned + hashed keys `cache:v2:<tool>:<sha256>` | **Gap** | `cacheKey()` returns `cache:${adapter}:${normalized}` — no version, no hash. |
+| 3 | Canonical input (key version + tool + normalized args) | **Gap** | No canonical-input object exists; key is built from a single string. |
+| 4 | No truncated raw input as key | **Gap** | `cacheKey()` does `input.trim().toLowerCase().slice(0, 200)` — truncated raw input. |
+| 5 | No unsafe string-concatenated composite keys | **Gap** | `gov_landscape` (`query + github_url`), `finance_landscape` (`` `${tickers}|...` ``), `company_landscape` (`` `${company}|...` ``) all string-concat. |
+| 6 | Store structured raw entries, not stamped text | **Gap** | `withCache` stores `result.content[0].text` — the fully stamped/rendered envelope. |
+| 7 | Re-run stamp/envelope on cache hit | **Gap** | `getFromCache` only prepends `[⚡ Cached — retrieved at ...]`; no re-stamp. |
+| 8 | Cache hits refresh Retrieved | **Gap** | Stale `Retrieved:` from the original stamp is served verbatim. |
+| 9 | Cache hits recompute/preserve freshness_score | **Gap** | Stale `freshness_score` served; never recomputed. |
+| 10 | Additive cache metadata in JSON envelope | **Gap** | No `cache.status` / `cached_at` / `cache_age_seconds` / `ttl_seconds` / `key_version` fields. |
+| 11 | Do not cache hard errors | **Gap** | `withCache` calls `setInCache` unconditionally on every handler result. |
+| 12 | Do not cache empty output | **Gap** | No empty-output check before write. |
+| 13 | Do not cache malformed structured output | **Gap** | No malformed-output check before write. |
+| 14 | Do not cache hard adapter failures | **Gap** | `[ERROR]` / `adapterError` results are cached like successes. |
+| 15 | Do not cache uncertain partial composite failures | **Gap** | Composite outputs cached whole regardless of partial failures. |
+| 16 | Partial composites cache only marked non-empty content | **Gap** | No partial-failure marking or gating in cache write path. |
+| 17 | Cache writes use `ctx.waitUntil()` | **Gap** | `withCache` has no `ctx`; write is fire-and-forget `setInCache(...).catch(()=>{})`. |
+| 18 | Cache failures never crash the Worker | **Pass** | `getFromCache` / `setInCache` both wrap everything in `try/catch`. |
+| 19 | Structured cache logs without a large framework | **Gap** | No `cache_error` log event in `LogEventName`; cache failures are swallowed silently. |
+| 20 | Public output still includes Score/Retrieved/JSON/score/provenance | **Pass** | `stamp()` always emits `[FRESHCONTEXT]`, `Score:`, `Retrieved:`, `[FRESHCONTEXT_JSON]`, `freshness_score`, `freshness_confidence`, `adapter`. |
+| 21 | PR #5 GET /mcp lifecycle fix intact | **Pass** | `main` HEAD `0682010` has: awaited `transport.handleRequest`, OPTIONS→204, bad method→405, GET w/o SSE Accept→406, POST w/o JSON CT→415, 55s + abort-signal bounded SSE GET. |
+
+Summary: **3 Pass, 17 Gap, 0 Unknown, 1 Pass (item 21, must be preserved).** `main` does not satisfy the Pass 6 cache contract. The cache layer on `main` is the pre-Pass-6 v1-style implementation.
+
+## Required Patch Plan
+
+Gaps exist (items 2–17, 19). A code patch IS needed before any Pass 6 merge.
+
+The `pass6-cache-correctness-audit` branch already implements the full corrected cache layer (its diff vs `main` is +471/-67 in `worker/src/worker.ts`, plus the older `AUDIT_PASS6.md`). Its own audit claims items 2–19 are satisfied.
+
+**Recommended approach: manual transplant, not cherry-pick.**
+
+Minimal code changes needed (all confined to the Cache Layer + `withCache` region of `worker/src/worker.ts`, roughly lines 194–460 on `main`):
+
+1. Replace `CACHE_TTL` with the full 21-adapter map (verify each value against the TTL Table above).
+2. Replace `cacheKey()` with versioned + SHA-256 hashed canonical-input keying (`normalizeCacheArgs`, `sha256Hex`, `cacheKey` → `CacheKeyParts`).
+3. Replace the `FreshContext` cache entry shape with the structured `FreshContextCacheEntry` (raw fields, not stamped text).
+4. Rewrite `getFromCache` / `setInCache` to store/read structured entries, re-run `stamp()` on hit, and inject additive `cache` metadata.
+5. Rewrite `withCache` to: skip caching on error/empty/malformed/partial-failure output, accept structured candidates, and write via `ctx.waitUntil()` (requires threading `ctx` to `withCache`).
+6. Add `"cache_error"` to `LogEventName` and emit structured cache logs.
+7. Convert the 3 composite call sites (`gov_landscape`, `finance_landscape`, `company_landscape`) from string-concatenated keys to structured arg objects.
+
+Do NOT transplant `0f3ac8f fix: catch worker runtime promise failures` — it is a runtime/transport commit (out of Pass 6 scope) and overlaps the GET /mcp lifecycle region. `main` already has the newer, superior `0682010` fix there.
+
+## Risks
+
+- **Old Pass 6 branch diverged before current `main`.** `pass6-cache-correctness-audit` branches from `52b8d2b`; `main` has `4a86401` + `0682010` on top. The branch has never seen the GET /mcp lifecycle fix.
+- **`worker.ts` conflict risk.** The Pass 6 branch rewrote `worker.ts` against a pre-hotfix base. Any cherry-pick / merge of the Pass 6 branch will likely conflict in `worker.ts`.
+- **Accidental regression of the GET /mcp lifecycle fix.** Commit `0f3ac8f` on the Pass 6 branch touches runtime/transport error handling near the routing region. Cherry-picking or merging the branch wholesale could overwrite or revert the `0682010` lifecycle fix (406/405/415/204 + bounded SSE + awaited `handleRequest`). Manual transplant of ONLY the cache layer avoids this.
+- **Cache correctness must not change public schemas.** All `cache.*` metadata must be additive inside `[FRESHCONTEXT_JSON]`. `Score:`, `Retrieved:`, `[FRESHCONTEXT_JSON]`, `freshness_score`, confidence/provenance must remain.
+- **Stale KV entries.** Existing v1-style KV entries (`cache:<adapter>:<raw>`) and any earlier text-cached entries will not match new `cache:v2:...` keys; they are lazily ignored/expired, not actively purged.
+- **Known finance smoke false-positive.** A finance/MSFT smoke false-positive may already exist on `main`. It is NOT a Pass 6 bug and must NOT be fixed inside Pass 6.
+
+## Validation Plan
+
+Local (after the patch is approved and applied):
+
+```
+npm run build
+cd worker && npx tsc --noEmit
+npm run smoke:stdio
+```
+
+If `smoke:stdio` fails ONLY due to the known finance/MSFT false-positive that also reproduces on `main`, record it as pre-existing and do NOT fix it in Pass 6.
+
+Live checks — only if code changes are made AND deploy is explicitly approved:
+- `/health` returns ok
+- `tools/list` returns 21 tools
+- finance MSFT: first call = miss, second call = hit
+- cache `key_version` = `v2`
+- `Retrieved:` refreshes on cache hit
+- `freshness_score` is numeric / valid on hit
+- bad ticker returns `[ERROR]`
+- bad ticker output has NO `[FRESHCONTEXT_JSON]`
+- bad ticker result is NOT cached
+- invalid `/mcp` probes still return 204 / 405 / 406 / 415 as appropriate
+- fresh Ops Pulse 0.25h / 0.5h windows show 0 `scriptThrewException`
+
+## Final Recommendation
+
+**Manual transplant recommended. Cherry-pick unsafe.**
+
+- A patch IS needed before merge — `main` is on the pre-Pass-6 v1 cache layer (17 contract gaps).
+- The fix already exists on `pass6-cache-correctness-audit`, but that branch predates the GET /mcp lifecycle hotfix.
+- Cherry-picking `8c2e42e` / `8a7aec1` (and especially `0f3ac8f`) risks conflicting with or regressing the `0682010` GET /mcp fix.
+- Safer path: manually transplant ONLY the cache-layer region (`CACHE_TTL`, key derivation, structured entry shape, `getFromCache`/`setInCache`/`withCache`, `cache_error` logging, and the 3 composite call sites) onto current `main`, leaving the routing/transport region untouched.
+
+STOP — awaiting approval of this audit before patching `worker/src/worker.ts`.

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -22,7 +22,7 @@ interface Env {
   PH_TOKEN?: string;
 }
 
-type LogEventName = "adapter_error" | "route_error" | "cron_error" | "source_fetch_error" | "mcp_transport_lifecycle_error";
+type LogEventName = "adapter_error" | "route_error" | "cron_error" | "source_fetch_error" | "mcp_transport_lifecycle_error" | "cache_error";
 
 type LogFields = {
   request_id?: string;
@@ -35,6 +35,8 @@ type LogFields = {
   source_host?: string;
   status?: number;
   duration_ms?: number;
+  cache_key?: string;
+  ttl_seconds?: number;
   watched_query_id?: string;
   input_hash?: string;
   phase?: string;
@@ -192,53 +194,240 @@ async function ensureMigrations(env: Env): Promise<void> {
 
 // ─── Cache Layer ──────────────────────────────────────────────────────────────
 
+const CACHE_SCHEMA_VERSION = 2;
+
 const CACHE_TTL: Record<string, number> = {
-  jobs:          60 * 60 * 2,
-  github:        60 * 30,
-  hackernews:    60 * 15,
-  scholar:       60 * 60 * 6,
-  arxiv:         60 * 60 * 4,
-  yc:            60 * 60 * 4,
-  producthunt:   60 * 30,
-  reddit:        60 * 20,
-  finance:       60 * 5,
-  reposearch:    60 * 30,
-  packagetrends: 60 * 60 * 2,
+  github:             60 * 30,
+  hackernews:         60 * 15,
+  scholar:            60 * 60 * 6,
+  arxiv:              60 * 60 * 4,
+  reddit:             60 * 20,
+  yc:                 60 * 60 * 4,
+  producthunt:        60 * 30,
+  reposearch:         60 * 30,
+  packagetrends:      60 * 60 * 2,
+  finance:            60 * 5,
+  jobs:               60 * 60 * 2,
+  changelog:          60 * 60 * 2,
+  gdelt:              60 * 30,
+  gebiz:              60 * 60 * 6,
+  govcontracts:       60 * 60 * 6,
+  sec_filings:        60 * 60,
+  landscape:          60 * 15,
+  gov_landscape:      60 * 30,
+  finance_landscape:  60 * 5,
+  company_landscape:  60 * 60,
+  idea_landscape:     60 * 15,
 };
 const DEFAULT_TTL = 60 * 30;
 
-function cacheKey(adapter: string, input: string): string {
-  const normalized = input.trim().toLowerCase().slice(0, 200);
-  return `cache:${adapter}:${normalized}`;
+type CacheStatus = "hit" | "miss" | "bypass" | "write_skipped";
+
+interface CacheKeyParts {
+  key: string;
+  inputHash: string;
 }
 
-interface FreshContext {
-  content: string;
+interface FreshContextCacheEntry {
+  version: number;
+  key_version: string;
+  tool: string;
+  input_hash: string;
+  cached_at: string;
+  ttl_seconds: number;
+  expires_at: string;
   source_url: string;
   content_date: string | null;
-  retrieved_at: string;
   freshness_confidence: "high" | "medium" | "low";
-  adapter: string;
+  stamp_adapter: string;
+  content: string;
+  partial_failures: boolean;
 }
 
-async function getFromCache(kv: KVNamespace, adapter: string, input: string): Promise<FreshContext | null> {
+function normalizeCacheString(input: string): string {
+  const trimmed = input.trim().replace(/\s+/g, " ");
   try {
-    const key = cacheKey(adapter, input);
-    const raw = await kv.get(key);
+    const parsed = new URL(trimmed);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.hash = "";
+    const params = [...parsed.searchParams.entries()]
+      .sort(([ak, av], [bk, bv]) => ak === bk ? av.localeCompare(bv) : ak.localeCompare(bk));
+    parsed.search = params.length ? new URLSearchParams(params).toString() : "";
+    return parsed.toString();
+  } catch {
+    return trimmed.toLowerCase();
+  }
+}
+
+function normalizeCacheArgs(input: unknown): unknown {
+  if (input === null || input === undefined) return null;
+  if (typeof input === "string") return normalizeCacheString(input);
+  if (typeof input === "number" || typeof input === "boolean") return input;
+  if (Array.isArray(input)) return input.map(normalizeCacheArgs);
+  if (typeof input === "object") {
+    const normalized: Record<string, unknown> = {};
+    for (const key of Object.keys(input as Record<string, unknown>).sort()) {
+      const value = (input as Record<string, unknown>)[key];
+      if (value !== undefined) normalized[key] = normalizeCacheArgs(value);
+    }
+    return normalized;
+  }
+  return String(input);
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  if (!globalThis.crypto?.subtle) return simpleHash(value);
+  const encoded = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function buildCacheKey(toolName: string, input: unknown): Promise<CacheKeyParts> {
+  const normalizedTool = toolName.toLowerCase();
+  const canonical = JSON.stringify({
+    key_version: `v${CACHE_SCHEMA_VERSION}`,
+    tool: normalizedTool,
+    args: normalizeCacheArgs(input),
+  });
+  const inputHash = await sha256Hex(canonical);
+  return {
+    key: `cache:v${CACHE_SCHEMA_VERSION}:${normalizedTool}:${inputHash}`,
+    inputHash,
+  };
+}
+
+function parseFreshContextJson(text: string): Record<string, any> | null {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  if (!match) return null;
+  try { return JSON.parse(match[1]) as Record<string, any>; } catch { return null; }
+}
+
+function replaceFreshContextJson(text: string, structured: Record<string, any>): string {
+  const block = [
+    "[FRESHCONTEXT_JSON]",
+    JSON.stringify(structured, null, 2),
+    "[/FRESHCONTEXT_JSON]",
+  ].join("\n");
+  return text.replace(/\[FRESHCONTEXT_JSON\]\s*[\s\S]*?\s*\[\/FRESHCONTEXT_JSON\]/, block);
+}
+
+function isUncacheableContent(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return true;
+  if (/^\[ERROR\]/i.test(trimmed)) return true;
+  return false;
+}
+
+// Analyses raw composite content (the unstamped body before [FRESHCONTEXT] wrapping).
+// Only composite tools use "## Section" headers; single-adapter outputs do not, so
+// inSection never flips true for them and both flags stay false.
+function analyzeCompositeContent(content: string): { allUnavailable: boolean; hasPartialFailures: boolean } {
+  const lines = content.split(/\r?\n/);
+  let inSection = false;
+  let hasUsefulContent = false;
+  let hasUnavailableContent = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("## ")) { inSection = true; continue; }
+    if (!inSection || !trimmed) continue;
+    // Matches [Unavailable: reason] (section() helper) and bare "Error" (landscape tool).
+    if (trimmed.startsWith("[Unavailable:") || trimmed === "Error") {
+      hasUnavailableContent = true;
+    } else {
+      hasUsefulContent = true;
+    }
+  }
+  return {
+    allUnavailable: inSection && !hasUsefulContent,
+    hasPartialFailures: inSection && hasUnavailableContent,
+  };
+}
+
+async function getFromCache(
+  kv: KVNamespace,
+  toolName: string,
+  input: unknown,
+): Promise<{ text: string; status: CacheStatus } | null> {
+  let keyParts: CacheKeyParts;
+  try {
+    keyParts = await buildCacheKey(toolName, input);
+  } catch (err) {
+    logEvent("cache_error", { tool: toolName, phase: "key_build_read" }, err);
+    return null;
+  }
+  try {
+    const raw = await kv.get(keyParts.key);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as FreshContext & { _cached_at: string };
-    parsed.content = `[⚡ Cached — retrieved at ${parsed._cached_at}]\n\n` + parsed.content;
-    return parsed;
-  } catch { return null; }
+    const entry = JSON.parse(raw) as FreshContextCacheEntry;
+    if (entry.version !== CACHE_SCHEMA_VERSION) return null;
+    const now = new Date();
+    const cachedAt = new Date(entry.cached_at);
+    const cacheAgeSeconds = Math.floor((now.getTime() - cachedAt.getTime()) / 1000);
+    const freshText = stamp(entry.content, entry.source_url, entry.content_date, entry.freshness_confidence, entry.stamp_adapter);
+    const cacheMetadata: Record<string, unknown> = {
+      status: "hit" as CacheStatus,
+      cached_at: entry.cached_at,
+      cache_age_seconds: cacheAgeSeconds,
+      ttl_seconds: entry.ttl_seconds,
+      key_version: entry.key_version,
+    };
+    const parsed = parseFreshContextJson(freshText);
+    if (parsed) {
+      return { text: replaceFreshContextJson(freshText, { ...parsed, cache: cacheMetadata }), status: "hit" };
+    }
+    return { text: freshText, status: "hit" };
+  } catch (err) {
+    logEvent("cache_error", { tool: toolName, cache_key: keyParts.key, phase: "read" }, err);
+    return null;
+  }
 }
 
-async function setInCache(kv: KVNamespace, adapter: string, input: string, result: FreshContext): Promise<void> {
+async function setInCache(
+  kv: KVNamespace,
+  toolName: string,
+  input: unknown,
+  text: string,
+  adapter: string,
+): Promise<void> {
+  if (isUncacheableContent(text)) return;
+  const parsed = parseFreshContextJson(text);
+  if (!parsed) return;
+  const fc = parsed.freshcontext as Record<string, any> | undefined;
+  if (!fc) return;
+  const compositeAnalysis = analyzeCompositeContent(parsed.content ?? "");
+  if (compositeAnalysis.allUnavailable) return;
+  let keyParts: CacheKeyParts;
   try {
-    const key = cacheKey(adapter, input);
-    const ttl = CACHE_TTL[adapter.toLowerCase()] ?? DEFAULT_TTL;
-    const payload = JSON.stringify({ ...result, _cached_at: new Date().toISOString() });
-    await kv.put(key, payload, { expirationTtl: ttl });
-  } catch { /* non-fatal */ }
+    keyParts = await buildCacheKey(toolName, input);
+  } catch (err) {
+    logEvent("cache_error", { tool: toolName, phase: "key_build_write" }, err);
+    return;
+  }
+  const ttl = CACHE_TTL[adapter.toLowerCase()] ?? DEFAULT_TTL;
+  const now = new Date();
+  const entry: FreshContextCacheEntry = {
+    version: CACHE_SCHEMA_VERSION,
+    key_version: `v${CACHE_SCHEMA_VERSION}`,
+    tool: toolName,
+    input_hash: keyParts.inputHash,
+    cached_at: now.toISOString(),
+    ttl_seconds: ttl,
+    expires_at: new Date(now.getTime() + ttl * 1000).toISOString(),
+    source_url: fc.source_url ?? "",
+    content_date: fc.content_date ?? null,
+    freshness_confidence: fc.freshness_confidence ?? "medium",
+    stamp_adapter: fc.adapter ?? adapter,
+    content: parsed.content ?? "",
+    partial_failures: compositeAnalysis.hasPartialFailures,
+  };
+  try {
+    await kv.put(keyParts.key, JSON.stringify(entry), { expirationTtl: ttl });
+  } catch (err) {
+    logEvent("cache_error", { tool: toolName, cache_key: keyParts.key, ttl_seconds: ttl, phase: "write" }, err);
+  }
 }
 
 // ─── Security ─────────────────────────────────────────────────────────────────
@@ -404,18 +593,21 @@ type ToolResult = { content: Array<{ type: "text"; text: string }> };
 
 async function withCache(
   adapter: string,
-  cacheInput: string,
+  cacheInput: unknown,
   kv: KVNamespace,
+  ctx: ExecutionContext | null,
   handler: () => Promise<ToolResult>
 ): Promise<ToolResult> {
   const cached = await getFromCache(kv, adapter, cacheInput);
-  if (cached) return { content: [{ type: "text", text: cached.content }] };
+  if (cached) return { content: [{ type: "text", text: cached.text }] };
   const result = await handler();
   const text = result.content[0]?.text ?? "";
-  setInCache(kv, adapter, cacheInput, {
-    content: text, source_url: cacheInput, content_date: null,
-    retrieved_at: new Date().toISOString(), freshness_confidence: "medium", adapter,
-  }).catch(() => {});
+  const writePromise = setInCache(kv, adapter, cacheInput, text, adapter);
+  if (ctx) {
+    ctx.waitUntil(writePromise);
+  } else {
+    writePromise.catch(() => {});
+  }
   return result;
 }
 
@@ -1067,7 +1259,7 @@ async function fetchProductHunt(query: string, maxLength: number, phToken?: stri
 
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
-function createServer(env: Env, requestLog: LogFields = {}): McpServer {
+function createServer(env: Env, ctx: ExecutionContext | null, requestLog: LogFields = {}): McpServer {
   const server = new McpServer({ name: "freshcontext-mcp", version: SERVICE_VERSION });
 
   const ok = (text: string): ToolResult => ({ content: [{ type: "text", text }] });
@@ -1087,7 +1279,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().url().describe("Full GitHub repo URL e.g. https://github.com/owner/repo") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("github", url, env.CACHE, async () => {
+    return withCache("github", url, env.CACHE, ctx, async () => {
       try {
         const safeUrl = validateUrl(url, "github");
         const browser = await puppeteer.launch(env.BROWSER);
@@ -1122,7 +1314,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().min(1).describe("HN URL e.g. https://news.ycombinator.com/news, Algolia API URL, or search query e.g. 'browser agents'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("hackernews", url, env.CACHE, async () => {
+    return withCache("hackernews", url, env.CACHE, ctx, async () => {
       try {
         let parsedInput: URL | null = null;
         try { parsedInput = new URL(url); } catch { parsedInput = null; }
@@ -1172,7 +1364,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().url().describe("Google Scholar search URL") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("scholar", url, env.CACHE, async () => {
+    return withCache("scholar", url, env.CACHE, ctx, async () => {
       try {
         const safeUrl = validateUrl(url, "scholar");
         const browser = await puppeteer.launch(env.BROWSER);
@@ -1202,7 +1394,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().url().describe("YC URL e.g. https://www.ycombinator.com/companies?query=mcp") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("yc", url, env.CACHE, async () => {
+    return withCache("yc", url, env.CACHE, ctx, async () => {
       try {
         const safeUrl = validateUrl(url, "yc");
         const browser = await puppeteer.launch(env.BROWSER);
@@ -1231,7 +1423,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ query: z.string().describe("Search query e.g. 'mcp server typescript'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ query }) => {
-    return withCache("reposearch", query, env.CACHE, async () => {
+    return withCache("reposearch", query, env.CACHE, ctx, async () => {
       try {
         const q = query.replace(/[\x00-\x1F]/g, "").trim().slice(0, 200);
         const ghHeaders: Record<string, string> = { "User-Agent": SERVICE_UA, "Accept": "application/vnd.github+json" };
@@ -1255,7 +1447,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ packages: z.string().describe("Package name(s) e.g. 'langchain' or 'npm:zod,pypi:fastapi'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ packages }) => {
-    return withCache("packagetrends", packages, env.CACHE, async () => {
+    return withCache("packagetrends", packages, env.CACHE, ctx, async () => {
       try {
         const entries = packages.split(",").map(s => s.trim()).filter(Boolean).slice(0, 5);
         const results: string[] = [];
@@ -1287,7 +1479,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Subreddit name e.g. 'r/MachineLearning' or search URL") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("reddit", url, env.CACHE, async () => {
+    return withCache("reddit", url, env.CACHE, ctx, async () => {
       try {
         let apiUrl = url;
         if (!apiUrl.startsWith("http")) {
@@ -1318,7 +1510,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Search query or PH topic URL") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("producthunt", url, env.CACHE, async () => {
+    return withCache("producthunt", url, env.CACHE, ctx, async () => {
       try {
         const isUrl = url.startsWith("http");
         const gql = `{ posts(first: 20, order: VOTES${isUrl ? "" : `, search: ${JSON.stringify(url)}`}) { edges { node { name tagline url votesCount commentsCount createdAt topics { edges { node { name } } } } } } }`;
@@ -1346,7 +1538,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Ticker symbol(s) e.g. 'AAPL' or 'MSFT,GOOG'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("finance", url, env.CACHE, async () => {
+    return withCache("finance", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchFinance(url, 5000, adapterLog("extract_finance", "finance", url));
         return ok(stamp(r.raw, `stooq:${url}`, r.date, r.conf, "finance"));
@@ -1362,7 +1554,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ query, max_length }) => {
-    return withCache("jobs", query, env.CACHE, async () => {
+    return withCache("jobs", query, env.CACHE, ctx, async () => {
       try {
         const q = query.replace(/[\x00-\x1F]/g, "").trim().slice(0, 200);
         const perSource = Math.floor((max_length ?? 6000) / 2);
@@ -1399,7 +1591,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ topic: z.string().describe("Project idea or keyword e.g. 'mcp server'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ topic }) => {
-    return withCache("landscape", topic, env.CACHE, async () => {
+    return withCache("landscape", topic, env.CACHE, ctx, async () => {
       try {
         const t = topic.replace(/[\x00-\x1F]/g, "").trim().slice(0, 200);
         const [hn, repos, pkg] = await Promise.allSettled([
@@ -1434,7 +1626,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Search query e.g. 'temporal retrieval', or a full arXiv API URL") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("arxiv", url, env.CACHE, async () => {
+    return withCache("arxiv", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchArxiv(url, 6000, adapterLog("extract_arxiv", "arxiv", url));
         const source = url.startsWith("http") ? url : `arxiv:${url}`;
@@ -1449,7 +1641,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("GitHub repo URL or npm package name e.g. 'react'") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("changelog", url, env.CACHE, async () => {
+    return withCache("changelog", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchChangelog(url, 6000, adapterLog("extract_changelog", "changelog", url));
         return ok(stamp(r.raw, `changelog:${url}`, r.date, r.conf, "changelog"));
@@ -1463,7 +1655,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Query: company name, topic, or keyword") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("gdelt", url, env.CACHE, async () => {
+    return withCache("gdelt", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchGdelt(url, 6000, adapterLog("extract_gdelt", "gdelt", url));
         return ok(stamp(r.raw, `gdelt:${url}`, r.date, r.conf, "gdelt"));
@@ -1477,7 +1669,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Keyword, agency, or empty for latest tenders") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("gebiz", url, env.CACHE, async () => {
+    return withCache("gebiz", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchGebiz(url, 6000, adapterLog("extract_gebiz", "gebiz", url));
         return ok(stamp(r.raw, `gebiz:${url || "all"}`, r.date, r.conf, "gebiz"));
@@ -1491,7 +1683,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Company name, keyword, or NAICS code") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("govcontracts", url, env.CACHE, async () => {
+    return withCache("govcontracts", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchGovContracts(url, 6000, adapterLog("extract_govcontracts", "govcontracts", url));
         return ok(stamp(r.raw, `govcontracts:${url}`, r.date, r.conf, "govcontracts"));
@@ -1505,7 +1697,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     inputSchema: z.object({ url: z.string().describe("Company name, ticker, or keyword") }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ url }) => {
-    return withCache("sec_filings", url, env.CACHE, async () => {
+    return withCache("sec_filings", url, env.CACHE, ctx, async () => {
       try {
         const r = await fetchSecFilings(url, 6000, adapterLog("extract_sec_filings", "sec_filings", url));
         return ok(stamp(r.raw, `sec:${url}`, r.date, r.conf, "sec_filings"));
@@ -1550,7 +1742,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ query, github_url }) => {
-    return withCache("gov_landscape", query + (github_url ?? ""), env.CACHE, async () => {
+    return withCache("gov_landscape", { query, github_url: github_url ?? null }, env.CACHE, ctx, async () => {
       const per = 3000;
       const repoQuery = github_url ?? query;
       const [contracts, hn, repos, changelog] = await Promise.allSettled([
@@ -1587,7 +1779,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ tickers, company_name, github_query }) => {
-    return withCache("finance_landscape", `${tickers}|${company_name ?? ""}|${github_query ?? ""}`, env.CACHE, async () => {
+    return withCache("finance_landscape", { tickers, company_name: company_name ?? null, github_query: github_query ?? null }, env.CACHE, ctx, async () => {
       const per = 2400;
       const searchTerm = company_name ?? tickers.split(",")[0].trim();
       const repoQuery = github_query ?? searchTerm;
@@ -1628,7 +1820,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ company, ticker, github_url }) => {
-    return withCache("company_landscape", `${company}|${ticker ?? ""}|${github_url ?? ""}`, env.CACHE, async () => {
+    return withCache("company_landscape", { company, ticker: ticker ?? null, github_url: github_url ?? null }, env.CACHE, ctx, async () => {
       const per = 3000;
       const repoQuery = github_url ?? company;
       const [sec, contracts, gdelt, changelog, finance] = await Promise.allSettled([
@@ -1666,7 +1858,7 @@ function createServer(env: Env, requestLog: LogFields = {}): McpServer {
     }),
     annotations: { readOnlyHint: true, openWorldHint: true },
   }, async ({ idea }) => {
-    return withCache("idea_landscape", idea, env.CACHE, async () => {
+    return withCache("idea_landscape", idea, env.CACHE, ctx, async () => {
       const per = 2200;
       const [hn, yc, repos, jobs, pkg, ph] = await Promise.allSettled([
         fetchHN(idea, per, adapterLog("extract_idea_landscape", "hackernews", idea)),
@@ -2045,7 +2237,7 @@ function isBotProbe(url: URL, ua: string): boolean {
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const ua = request.headers.get("User-Agent") ?? "";
     const requestLog: LogFields = {
@@ -2388,7 +2580,7 @@ export default {
 
     try {
       const transport = new WebStandardStreamableHTTPServerTransport();
-      const server = createServer(env, requestLog);
+      const server = createServer(env, ctx, requestLog);
       await server.connect(transport);
 
       // For SSE GET: race the transport against a combined abort signal (client


### PR DESCRIPTION
## Summary

Implements Pass 6 cache correctness on current main while preserving the merged GET /mcp lifecycle hotfix.

## Changes

- Adds `AUDIT_PASS6.md`
- Uses versioned hashed cache keys: `cache:v2:<toolName>:<sha256(canonicalInput)>`
- Uses structured canonical cache inputs
- Stores structured raw cache entries instead of final stamped text
- Re-runs stamping/envelope generation on cache hits
- Refreshes `Retrieved` on cache hits
- Adds cache metadata to JSON envelopes
- Skips hard errors, empty output, malformed output, hard adapter failures, and all-unavailable composite failures
- Marks mixed useful partial composites with `partial_failures`
- Uses `ctx.waitUntil()` for cache writes where available
- Logs cache failures without crashing Worker
- Preserves `/mcp` transport lifecycle guards from PR #5

## Live Verification

- Cache verification passed live.
- v2 cache hit metadata verified.
- Retrieved refresh verified.
- bad ticker remains uncached.
- tools/list remains 21.
- /mcp guard probes still return 204/406/405/415.

## Runtime Note

- Fresh runtime windows showed GET /mcp SSE scriptThrewException.
- Rollback to main reproduced the same GET /mcp SSE scriptThrewException pattern.
- Therefore this is not currently attributed to Pass 6, but PR remains draft until separate runtime issue is resolved or accepted.

## Validation

- `npm run build` clean
- `cd worker && npx tsc --noEmit` clean
- `npm run smoke:stdio` — ok, tool_count: 21