### PR TITLE
fix: reject stateless mcp sse get probes

### DIFF
--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -2348,6 +2348,23 @@ export default {
         console.log(JSON.stringify({ event: "mcp_sse_get_aborted", phase: "pre_transport", ...requestLog }));
         return new Response(null, { status: 204 });
       }
+      // Stateless transport: no sessionIdGenerator, so this server never issues an
+      // mcp-session-id. A standalone GET SSE stream therefore can never carry data —
+      // the SDK hands back an open ReadableStream that hangs until Cloudflare cancels
+      // the Worker (scriptThrewException). Reject GET SSE without a session header fast
+      // instead of constructing a transport whose stream never closes.
+      const sseSessionId = request.headers.get("mcp-session-id");
+      if (!sseSessionId) {
+        console.log(JSON.stringify({ event: "mcp_sse_get_rejected", phase: "no_session", ...requestLog }));
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32000, message: "Bad Request: Mcp-Session-Id header is required for GET /mcp SSE. Use POST /mcp for JSON-RPC." },
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } }
+        );
+      }
       console.log(JSON.stringify({ event: "mcp_sse_get_start", ...requestLog }));
     }
 


### PR DESCRIPTION
## Summary

Fixes the remaining GET `/mcp` SSE hung-worker path on the stateless MCP Worker.

## Root cause

The Worker runs `WebStandardStreamableHTTPServerTransport` without a session id generator/event store, so it is effectively stateless.

Scanner/probe requests could send:

- `GET /mcp`
- `Accept: text/event-stream`
- no `mcp-session-id`

Those requests passed the previous SSE Accept guard and reached the SDK transport. The SDK returned an idle SSE `ReadableStream`, but there was no session and no data path. The prior 55s AbortController signal did not close the detached response stream, so Cloudflare eventually canceled the request as a hung Worker, producing `scriptThrewException`.

## Change

Adds a pre-transport guard:

- `GET /mcp` with `Accept: text/event-stream` but missing `mcp-session-id` now returns structured HTTP `400`
- message tells clients to use `POST /mcp` for JSON-RPC
- no transport or SSE stream is constructed for invalid stateless GET probes

## Preserved behavior

- bare `GET /mcp` -> `406`
- `OPTIONS /mcp` -> `204`
- unsupported methods -> `405`
- bad `POST /mcp` content type -> `415`
- valid `POST /mcp` remains working
- `tools/list` still returns 21 tools
- MCP version remains `0.3.17`

## Validation

Local:

- `npm run build`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio`
- tool count: 21

Live:

- deployed Worker version `9b818a15-65fa-4be2-b601-df9db16ef66c`
- GET SSE without `mcp-session-id` returns `400`
- bare GET returns `406`
- OPTIONS returns `204`
- PATCH returns `405`
- POST without JSON content type returns `415`
- POST `tools/list` returns `200` and 21 tools
- Ops Pulse 0.1h reports `freshcontext-mcp` healthy with 0 errors
- no fresh `scriptThrewException`
- logs show GET `/mcp` SSE probes resolving immediately as `400` / `ok`