### PR TITLE
Pass 7 Phase 1 — characterization tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
-    "test": "jest"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/scripts/smoke-stdio.mjs
+++ b/scripts/smoke-stdio.mjs
@@ -26,7 +26,9 @@ function parseFreshContextJson(text) {
 }
 
 function assertNoMisleadingFailureEnvelope(text, label) {
-  if (/\b(?:Error|ERROR|401|403|404|429|failed)\b/.test(text)) {
+  const failurePattern =
+    /\[(?:error|security)\]|(?:^|\n)(?:error|failed|failure|timeout|upstream)\b|Yahoo Finance API error|query1\.finance\.yahoo\.com|\b(?:HTTP|status|error)\s*:?\s*(?:401|403|404|429|5\d\d)\b|\b(?:401|403|404|429|5\d\d)\b[^\n]*(?:error|failed|failure|timeout)/i;
+  if (failurePattern.test(text)) {
     assert(!/Confidence:\s*high/i.test(text), `${label}: failure content must not be Confidence: high`);
     assert(!/Score:\s*100\/100/i.test(text), `${label}: failure content must not be Score: 100/100`);
   }
@@ -77,7 +79,7 @@ try {
     name: "extract_finance",
     arguments: { url: "MSFT", max_length: 2000 },
   }));
-  assert(!/Yahoo Finance API error|query1\.finance|401/.test(finance), "Finance still exposes Yahoo 401 path");
+  assert(!/Yahoo Finance API error|query1\.finance\.yahoo\.com|\[MSFT\].*401|Yahoo 401/i.test(finance), "Finance still exposes Yahoo 401 path");
   assert(/source:\s*stooq/i.test(finance), "Finance output missing source: stooq");
   assertNoMisleadingFailureEnvelope(finance, "finance MSFT");
   parseFreshContextJson(finance);

--- a/tests/freshnessStamp.test.ts
+++ b/tests/freshnessStamp.test.ts
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stampFreshness, formatForLLM } from "../src/tools/freshnessStamp.js";
+import type { AdapterResult, FreshContext } from "../src/types.js";
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+function stamp(
+  result: AdapterResult,
+  adapter = "hackernews",
+  url = "https://example.com/item"
+): FreshContext {
+  return stampFreshness(result, { url, maxLength: 8000 }, adapter);
+}
+
+function parseFreshContextJson(text: string): {
+  freshcontext: {
+    source_url: string;
+    content_date: string | null;
+    retrieved_at: string;
+    freshness_confidence: "high" | "medium" | "low";
+    freshness_score: number | null;
+    adapter: string;
+  };
+  content: string;
+} {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  assert.ok(match, "Missing [FRESHCONTEXT_JSON] block");
+  return JSON.parse(match[1]);
+}
+
+test("valid ISO content_date produces a numeric freshness_score", () => {
+  const ctx = stamp({
+    raw: "A real retrieved result",
+    content_date: hoursAgo(2),
+    freshness_confidence: "high",
+  });
+
+  assert.equal(typeof ctx.freshness_score, "number");
+  assert.ok(ctx.freshness_score !== null && ctx.freshness_score >= 0 && ctx.freshness_score <= 100);
+});
+
+test("missing content_date produces null freshness_score", () => {
+  const ctx = stamp({
+    raw: "A result with no publish date",
+    content_date: null,
+    freshness_confidence: "medium",
+  });
+
+  assert.equal(ctx.freshness_score, null);
+});
+
+test("invalid content_date produces null freshness_score", () => {
+  const ctx = stamp({
+    raw: "A result with an invalid publish date",
+    content_date: "not-a-date",
+    freshness_confidence: "medium",
+  });
+
+  assert.equal(ctx.freshness_score, null);
+});
+
+test("adapter-specific decay behavior is preserved", () => {
+  const content_date = hoursAgo(48);
+  const result: AdapterResult = {
+    raw: "Same signal, different adapter decay",
+    content_date,
+    freshness_confidence: "high",
+  };
+
+  const hn = stamp(result, "hackernews");
+  const github = stamp(result, "github");
+
+  assert.equal(typeof hn.freshness_score, "number");
+  assert.equal(typeof github.freshness_score, "number");
+  assert.ok((github.freshness_score ?? 0) > (hn.freshness_score ?? 0));
+});
+
+test("future dates beyond tolerance are not treated as fresh", { skip: "Current MCP stamping clamps future dates to fresh; activate when Core guards are extracted." }, () => {
+  const ctx = stamp({
+    raw: "Future-dated result",
+    content_date: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    freshness_confidence: "high",
+  });
+
+  assert.notEqual(ctx.freshness_score, 100);
+});
+
+test("text envelope includes FreshContext fields", () => {
+  const ctx = stamp({
+    raw: "Envelope content",
+    content_date: hoursAgo(1),
+    freshness_confidence: "high",
+  });
+  const text = formatForLLM(ctx);
+
+  assert.match(text, /\[FRESHCONTEXT\]/);
+  assert.match(text, /Source: https:\/\/example\.com\/item/);
+  assert.match(text, /Published:/);
+  assert.match(text, /Retrieved:/);
+  assert.match(text, /Confidence: high/);
+  assert.match(text, /\[\/FRESHCONTEXT\]/);
+});
+
+test("structured JSON envelope exposes freshness metadata", () => {
+  const ctx = stamp({
+    raw: "Structured content",
+    content_date: hoursAgo(1),
+    freshness_confidence: "high",
+  });
+  const parsed = parseFreshContextJson(formatForLLM(ctx));
+
+  assert.equal(parsed.freshcontext.source_url, "https://example.com/item");
+  assert.equal(parsed.freshcontext.content_date, ctx.content_date);
+  assert.equal(parsed.freshcontext.retrieved_at, ctx.retrieved_at);
+  assert.equal(parsed.freshcontext.freshness_confidence, "high");
+  assert.equal(parsed.freshcontext.freshness_score, ctx.freshness_score);
+  assert.equal(parsed.freshcontext.adapter, "hackernews");
+});
+
+test("error-looking adapter output downgrades confidence and clears content_date", () => {
+  const ctx = stamp({
+    raw: "[Error] upstream timeout",
+    content_date: hoursAgo(1),
+    freshness_confidence: "high",
+  });
+  const text = formatForLLM(ctx);
+
+  assert.equal(ctx.content_date, null);
+  assert.equal(ctx.freshness_confidence, "low");
+  assert.equal(ctx.freshness_score, null);
+  assert.doesNotMatch(text, /Confidence:\s*high/i);
+  assert.doesNotMatch(text, /Score:\s*100\/100/i);
+});
+
+test("empty, security, and timeout-only output are treated as low-confidence failures", () => {
+  const cases: string[] = [
+    "",
+    "[Security] Domain not allowed",
+    "timeout",
+    "failed\n404",
+  ];
+
+  for (const raw of cases) {
+    const ctx = stamp({
+      raw,
+      content_date: hoursAgo(1),
+      freshness_confidence: "high",
+    });
+
+    assert.equal(ctx.content_date, null, `content_date should be cleared for ${JSON.stringify(raw)}`);
+    assert.equal(ctx.freshness_confidence, "low", `confidence should be low for ${JSON.stringify(raw)}`);
+    assert.equal(ctx.freshness_score, null, `freshness_score should be null for ${JSON.stringify(raw)}`);
+    assert.doesNotMatch(formatForLLM(ctx), /Score:\s*100\/100/i);
+  }
+});

--- a/tests/hackernews.test.ts
+++ b/tests/hackernews.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { hackerNewsAdapter } from "../src/adapters/hackernews.js";
+import { stampFreshness, formatForLLM } from "../src/tools/freshnessStamp.js";
+
+function parseFreshContextJson(text: string): {
+  freshcontext: {
+    source_url: string;
+    content_date: string | null;
+    retrieved_at: string;
+    freshness_confidence: "high" | "medium" | "low";
+    freshness_score: number | null;
+    adapter: string;
+  };
+  content: string;
+} {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  assert.ok(match, "Missing [FRESHCONTEXT_JSON] block");
+  return JSON.parse(match[1]);
+}
+
+test("plain text Hacker News query path remains accepted and uses Algolia search", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  globalThis.fetch = async (input: string | URL | Request) => {
+    const url = String(input);
+    requestedUrls.push(url);
+
+    return new Response(JSON.stringify({
+      hits: [
+        {
+          title: "Browser agents are getting useful",
+          url: "https://example.com/browser-agents",
+          points: 42,
+          num_comments: 12,
+          author: "pg",
+          created_at: "2026-05-13T10:00:00.000Z",
+          objectID: "123",
+        },
+      ],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const result = await hackerNewsAdapter({ url: "browser agents", maxLength: 4000 });
+
+    assert.equal(requestedUrls.length, 1);
+    assert.match(requestedUrls[0], /^https:\/\/hn\.algolia\.com\/api\/v1\/search\?/);
+    assert.match(requestedUrls[0], /query=browser%20agents/);
+    assert.match(result.raw, /Browser agents are getting useful/);
+    assert.equal(result.content_date, "2026-05-13T10:00:00.000Z");
+    assert.equal(result.freshness_confidence, "high");
+    assert.doesNotThrow(() => new Date(result.content_date ?? "").toISOString());
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("Hacker News stamped output remains FreshContext-compatible", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    hits: [
+      {
+        title: "FreshContext Core extraction",
+        url: null,
+        points: 17,
+        num_comments: 5,
+        author: "hn_user",
+        created_at: "2026-05-13T09:30:00Z",
+        objectID: "456",
+      },
+    ],
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+  try {
+    const result = await hackerNewsAdapter({ url: "freshcontext core", maxLength: 4000 });
+    const ctx = stampFreshness(result, { url: "freshcontext core", maxLength: 4000 }, "hackernews");
+    const text = formatForLLM(ctx);
+    const parsed = parseFreshContextJson(text);
+
+    assert.match(text, /\[FRESHCONTEXT\]/);
+    assert.match(text, /Source: freshcontext core/);
+    assert.match(text, /Published: 2026-05-13T09:30:00.000Z/);
+    assert.match(text, /Retrieved:/);
+    assert.match(text, /Confidence: high/);
+    assert.equal(parsed.freshcontext.source_url, "freshcontext core");
+    assert.equal(parsed.freshcontext.content_date, "2026-05-13T09:30:00.000Z");
+    assert.equal(parsed.freshcontext.freshness_confidence, "high");
+    assert.equal(parsed.freshcontext.adapter, "hackernews");
+    assert.equal(typeof parsed.freshcontext.freshness_score, "number");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

Restores Phase 1 characterization tests before FreshContext Core extraction.

## Changes

- Adds characterization tests for freshness/stamping/envelope behavior.
- Adds mocked Hacker News plain-query characterization tests.
- Updates `npm test` to run the Phase 1 test files through `tsx --test`.
- Updates stdio smoke guard to avoid the known finance/MSFT false-positive around valid values containing `401`.

## Validation

- `npm run build`
- `npm test` � 10 passed, 1 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` � 21 tools, version 0.3.17
- `git diff --check`

## Notes

- Does not extract `src/core/`.
- Does not change Worker runtime behavior.
- Does not change Pass 6 cache behavior.
- Does not change public MCP schemas.
- Does not change tool count.
- Skipped test documents the current future-date guard behavior and should be activated during Core guard extraction.