### PR TITLE
Pass 7 Phase 3D — pure Core rank and explain primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/core/explain.ts
+++ b/src/core/explain.ts
@@ -1,0 +1,44 @@
+import type { SignalConfidence } from "./types.js";
+
+interface ExplainSignalInput {
+  source?: string;
+  source_type?: string;
+  semantic_score: number;
+  freshness_score: number | null;
+  final_score: number;
+  confidence: SignalConfidence;
+  published_at?: string | null;
+}
+
+function sourceLabel(input: ExplainSignalInput): string {
+  return input.source_type || input.source || "source";
+}
+
+export function explainSignal(input: ExplainSignalInput): string {
+  const source = sourceLabel(input);
+
+  if (input.freshness_score === null) {
+    if (input.semantic_score < 0.5) {
+      return `Low confidence: weak semantic match and missing freshness data for ${source}.`;
+    }
+    return `Missing freshness data for ${source}; ranked mostly by semantic relevance.`;
+  }
+
+  if (input.semantic_score < 0.5) {
+    if (input.freshness_score >= 70) {
+      return `Fresh signal from ${source}, but semantic relevance is weak.`;
+    }
+    return `Weak semantic match with limited freshness for ${source}.`;
+  }
+
+  if (input.freshness_score >= 90) {
+    return `Strong semantic match and current freshness for ${source}.`;
+  }
+  if (input.freshness_score >= 70) {
+    return `Relevant signal with reliable freshness for ${source}.`;
+  }
+  if (input.freshness_score >= 50) {
+    return `Relevant signal, but freshness should be verified for ${source}.`;
+  }
+  return `Relevant signal, but stale for ${source}.`;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,14 @@
 export { LAMBDA, calculateFreshnessScore, scoreLabel } from "./decay.js";
 export { looksLikeFailedAdapterContent } from "./guards.js";
 export { stampFreshness, toStructuredJSON, formatForLLM } from "./envelope.js";
-export type { FreshContext, ExtractOptions, AdapterResult } from "./types.js";
+export { explainSignal } from "./explain.js";
+export { rankSignals, rankSignal, clampScore } from "./rank.js";
+export type {
+  FreshContext,
+  ExtractOptions,
+  AdapterResult,
+  SignalConfidence,
+  FreshSignal,
+  RankedSignal,
+  RankOptions,
+} from "./types.js";

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -1,0 +1,94 @@
+import { calculateFreshnessScore } from "./decay.js";
+import { explainSignal } from "./explain.js";
+import { looksLikeFailedAdapterContent } from "./guards.js";
+import type { FreshSignal, RankOptions, RankedSignal, SignalConfidence } from "./types.js";
+
+const DEFAULT_SEMANTIC_WEIGHT = 0.7;
+const DEFAULT_FRESHNESS_WEIGHT = 0.3;
+
+export function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function positiveNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function resolveWeights(options: RankOptions): { semantic: number; freshness: number } {
+  let semantic = positiveNumber(options.semanticWeight);
+  let freshness = positiveNumber(options.freshnessWeight);
+
+  if (semantic === 0 && freshness === 0) {
+    semantic = DEFAULT_SEMANTIC_WEIGHT;
+    freshness = DEFAULT_FRESHNESS_WEIGHT;
+  }
+
+  const total = semantic + freshness;
+  return {
+    semantic: semantic / total,
+    freshness: freshness / total,
+  };
+}
+
+function resolveRetrievedAt(signal: FreshSignal, options: RankOptions): string {
+  if (signal.retrieved_at) return signal.retrieved_at;
+  if (options.now instanceof Date) return options.now.toISOString();
+  if (typeof options.now === "string") return options.now;
+  return new Date().toISOString();
+}
+
+function resolveSourceType(signal: FreshSignal, options: RankOptions): string {
+  return signal.source_type ?? options.defaultSourceType ?? signal.source ?? "default";
+}
+
+function confidenceFor(signal: FreshSignal, semanticScore: number, freshnessScore: number | null): SignalConfidence {
+  if (signal.content !== undefined && looksLikeFailedAdapterContent(signal.content)) {
+    return "low";
+  }
+  if (freshnessScore !== null && semanticScore >= 0.7) {
+    return "high";
+  }
+  if (freshnessScore !== null || semanticScore >= 0.5) {
+    return "medium";
+  }
+  return "low";
+}
+
+export function rankSignal(signal: FreshSignal, options: RankOptions = {}): RankedSignal {
+  const weights = resolveWeights(options);
+  const semantic_score = clampScore(signal.semantic_score);
+  const freshness_score = calculateFreshnessScore(
+    signal.published_at ?? null,
+    resolveRetrievedAt(signal, options),
+    resolveSourceType(signal, options)
+  );
+  const freshnessComponent = freshness_score === null ? 0 : clampScore(freshness_score / 100);
+  const final_score = clampScore(
+    semantic_score * weights.semantic + freshnessComponent * weights.freshness
+  );
+  const confidence = confidenceFor(signal, semantic_score, freshness_score);
+
+  const ranked: Omit<RankedSignal, "reason"> = {
+    ...signal,
+    semantic_score,
+    freshness_score,
+    final_score,
+    confidence,
+  };
+
+  return {
+    ...ranked,
+    reason: explainSignal(ranked),
+  };
+}
+
+export function rankSignals(signals: FreshSignal[], options: RankOptions = {}): RankedSignal[] {
+  return signals
+    .map((signal, index) => ({ ranked: rankSignal(signal, options), index }))
+    .sort((a, b) => {
+      const scoreDiff = b.ranked.final_score - a.ranked.final_score;
+      return scoreDiff !== 0 ? scoreDiff : a.index - b.index;
+    })
+    .map(({ ranked }) => ranked);
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,3 +23,31 @@ export interface AdapterResult {
   content_date: string | null;
   freshness_confidence: "high" | "medium" | "low";
 }
+
+export type SignalConfidence = "high" | "medium" | "low";
+
+export interface FreshSignal {
+  id?: string;
+  source: string;
+  source_type?: string;
+  title?: string;
+  content?: string;
+  published_at?: string | null;
+  retrieved_at?: string | null;
+  semantic_score: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RankedSignal extends FreshSignal {
+  freshness_score: number | null;
+  final_score: number;
+  confidence: SignalConfidence;
+  reason: string;
+}
+
+export interface RankOptions {
+  semanticWeight?: number;
+  freshnessWeight?: number;
+  defaultSourceType?: string;
+  now?: Date | string;
+}

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -1,0 +1,171 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  clampScore,
+  explainSignal,
+  rankSignal,
+  rankSignals,
+} from "../src/core/index.js";
+import type { FreshSignal, RankedSignal, RankOptions } from "../src/core/index.js";
+
+const now = "2026-05-13T10:00:00.000Z";
+const options: RankOptions = { now, defaultSourceType: "hackernews" };
+
+test("rankSignals ranks fresh relevant signals above stale comparable signals", () => {
+  const signals: FreshSignal[] = [
+    {
+      id: "stale",
+      source: "https://example.com/stale",
+      source_type: "hackernews",
+      published_at: "2026-05-01T10:00:00.000Z",
+      semantic_score: 0.9,
+      content: "Stale but relevant signal",
+    },
+    {
+      id: "fresh",
+      source: "https://example.com/fresh",
+      source_type: "hackernews",
+      published_at: "2026-05-13T09:00:00.000Z",
+      semantic_score: 0.9,
+      content: "Fresh and relevant signal",
+    },
+  ];
+
+  const ranked = rankSignals(signals, options);
+
+  assert.equal(ranked[0].id, "fresh");
+  assert.equal(ranked[1].id, "stale");
+  assert.ok(ranked[0].final_score > ranked[1].final_score);
+});
+
+test("missing date still ranks with lower confidence and missing-date reason", () => {
+  const ranked = rankSignal({
+    id: "missing-date",
+    source: "https://example.com/missing",
+    source_type: "blog",
+    published_at: null,
+    semantic_score: 0.8,
+    content: "Relevant signal without date",
+  }, { now, defaultSourceType: "blog" });
+
+  assert.equal(ranked.freshness_score, null);
+  assert.equal(ranked.confidence, "medium");
+  assert.match(ranked.reason, /Missing freshness data/);
+  assert.ok(ranked.final_score > 0);
+  assert.ok(ranked.final_score < 0.8);
+});
+
+test("final_score and clampScore stay in the normalized 0..1 range", () => {
+  assert.equal(clampScore(-1), 0);
+  assert.equal(clampScore(2), 1);
+  assert.equal(clampScore(Number.NaN), 0);
+
+  const ranked = rankSignal({
+    source: "https://example.com/clamped",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    semantic_score: 2,
+    content: "Fresh signal with oversized semantic score",
+  }, { now, semanticWeight: 10, freshnessWeight: 10 });
+
+  assert.ok(ranked.final_score >= 0);
+  assert.ok(ranked.final_score <= 1);
+  assert.equal(ranked.semantic_score, 1);
+});
+
+test("rankSignals preserves input order when final scores tie", () => {
+  const signals: FreshSignal[] = [
+    {
+      id: "first",
+      source: "https://example.com/first",
+      source_type: "github",
+      published_at: "2026-05-13T09:00:00.000Z",
+      semantic_score: 0.75,
+      content: "First equivalent signal",
+    },
+    {
+      id: "second",
+      source: "https://example.com/second",
+      source_type: "github",
+      published_at: "2026-05-13T09:00:00.000Z",
+      semantic_score: 0.75,
+      content: "Second equivalent signal",
+    },
+  ];
+
+  const ranked = rankSignals(signals, options);
+
+  assert.equal(ranked[0].id, "first");
+  assert.equal(ranked[1].id, "second");
+});
+
+test("explainSignal returns deterministic reasons for key signal states", () => {
+  const fresh = rankSignal({
+    source: "https://example.com/current",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    semantic_score: 0.9,
+    content: "Current high relevance",
+  }, options);
+  const stale = rankSignal({
+    source: "https://example.com/stale",
+    source_type: "hackernews",
+    published_at: "2026-05-01T10:00:00.000Z",
+    semantic_score: 0.9,
+    content: "Stale high relevance",
+  }, options);
+  const missing = rankSignal({
+    source: "https://example.com/missing",
+    source_type: "blog",
+    published_at: null,
+    semantic_score: 0.8,
+    content: "Missing date",
+  }, options);
+  const weak = rankSignal({
+    source: "https://example.com/weak",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    semantic_score: 0.2,
+    content: "Fresh but weak",
+  }, options);
+
+  assert.equal(explainSignal(fresh), "Strong semantic match and current freshness for hackernews.");
+  assert.equal(explainSignal(stale), "Relevant signal, but stale for hackernews.");
+  assert.equal(explainSignal(missing), "Missing freshness data for blog; ranked mostly by semantic relevance.");
+  assert.equal(explainSignal(weak), "Fresh signal from hackernews, but semantic relevance is weak.");
+});
+
+test("rankSignals does not mutate the original input array or signal objects", () => {
+  const signals: FreshSignal[] = [
+    {
+      id: "original",
+      source: "https://example.com/original",
+      source_type: "hackernews",
+      published_at: "2026-05-13T09:00:00.000Z",
+      semantic_score: 0.9,
+      content: "Original signal",
+    },
+  ];
+  const snapshot = JSON.stringify(signals);
+
+  rankSignals(signals, options);
+
+  assert.equal(JSON.stringify(signals), snapshot);
+  assert.equal(Object.hasOwn(signals[0], "final_score"), false);
+});
+
+test("rank/explain public exports are available from src/core/index.ts", () => {
+  const ranked: RankedSignal = rankSignal({
+    source: "https://example.com/exported",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    semantic_score: 0.9,
+    content: "Exported API signal",
+  }, options);
+
+  assert.equal(typeof rankSignals, "function");
+  assert.equal(typeof rankSignal, "function");
+  assert.equal(typeof explainSignal, "function");
+  assert.equal(typeof clampScore, "function");
+  assert.equal(typeof ranked.reason, "string");
+});


### PR DESCRIPTION
## Summary

Adds pure Core ranking and explanation primitives without touching Worker, runtime, cache, feeds, or adapters.

## Changes

- Adds `src/core/rank.ts`
- Adds `src/core/explain.ts`
- Extends `src/core/types.ts`
- Exports rank/explain APIs from `src/core/index.ts`
- Adds `tests/rank.test.ts`
- Updates `npm test` to include rank tests

## Public API

- `rankSignals`
- `rankSignal`
- `clampScore`
- `explainSignal`
- `SignalConfidence`
- `FreshSignal`
- `RankedSignal`
- `RankOptions`

## Scoring

`final_score` is normalized from `0..1`.

Default formula:

`final_score = clamp01(semantic_score * 0.7 + freshnessComponent * 0.3)`

Where `freshness_score` is converted from `0..100` to `0..1`.

## Scope

This does not:

- modify `worker/src/worker.ts`
- modify `worker/src/intelligence.ts`
- modify `src/server.ts`
- modify Pass 6 cache behavior
- modify MCP transport behavior
- modify feed workers
- modify adapters
- migrate Worker scoring
- activate the skipped future-date guard test
- deploy production

## Validation

- `npm run build`
- `npm test` — 25 passed, 1 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `git diff --check`