### PR TITLE
Pass 7 Phase 3F-A — Worker envelope helper extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/tests/workerEnvelope.test.ts
+++ b/tests/workerEnvelope.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import freshcontextEnvelope from "../worker/src/freshcontextEnvelope.ts";
+
+const {
+  analyzeCompositeContent,
+  isUncacheableContent,
+  parseFreshContextJson,
+  replaceFreshContextJson,
+  stamp,
+} = freshcontextEnvelope;
+
+type WorkerEnvelope = {
+  freshcontext: {
+    source_url: string;
+    content_date: string | null;
+    retrieved_at: string;
+    freshness_confidence: "high" | "medium" | "low";
+    freshness_score: number | null;
+    adapter: string;
+  };
+  content: string;
+  cache?: Record<string, unknown>;
+};
+
+function parsedEnvelope(text: string): WorkerEnvelope {
+  const parsed = parseFreshContextJson(text);
+  assert.ok(parsed, "expected FreshContext JSON envelope");
+  return parsed as WorkerEnvelope;
+}
+
+test("Worker stamp emits Worker-style FreshContext text and JSON envelopes", () => {
+  const text = stamp(
+    "Worker envelope content",
+    "https://example.com/worker",
+    "2026-05-13T09:00:00.000Z",
+    "high",
+    "hackernews"
+  );
+  const parsed = parsedEnvelope(text);
+
+  assert.match(text, /\[FRESHCONTEXT\]/);
+  assert.match(text, /Source: https:\/\/example\.com\/worker/);
+  assert.match(text, /Published: 2026-05-13T09:00:00\.000Z/);
+  assert.match(text, /Retrieved:/);
+  assert.match(text, /Confidence: high/);
+  assert.match(text, /Score:/);
+  assert.match(text, /\[FRESHCONTEXT_JSON\]/);
+  assert.equal(parsed.freshcontext.source_url, "https://example.com/worker");
+  assert.equal(parsed.freshcontext.content_date, "2026-05-13T09:00:00.000Z");
+  assert.equal(parsed.freshcontext.freshness_confidence, "high");
+  assert.equal(parsed.freshcontext.adapter, "hackernews");
+  assert.equal(typeof parsed.freshcontext.freshness_score, "number");
+});
+
+test("Worker stamp missing date emits exact Worker unknown-date text", () => {
+  const text = stamp("No date content", "https://example.com/no-date", null, "medium", "hackernews");
+  const parsed = parsedEnvelope(text);
+
+  assert.match(text, /Published: unknown/);
+  assert.doesNotMatch(text, /Publish date: unknown/);
+  assert.equal(parsed.freshcontext.content_date, null);
+  assert.equal(parsed.freshcontext.freshness_score, null);
+});
+
+test("Worker stamp failure-looking content downgrades confidence and clears freshness", () => {
+  for (const raw of ["[Error] upstream timeout", "[Security] blocked", "timeout"]) {
+    const text = stamp(raw, "https://example.com/failure", "2026-05-13T09:00:00.000Z", "high", "hackernews");
+    const parsed = parsedEnvelope(text);
+
+    assert.match(text, /Confidence: low/);
+    assert.match(text, /Score: unknown/);
+    assert.equal(parsed.freshcontext.content_date, null);
+    assert.equal(parsed.freshcontext.freshness_confidence, "low");
+    assert.equal(parsed.freshcontext.freshness_score, null);
+  }
+});
+
+test("Worker stamp truncates content at 6000 characters", () => {
+  const longContent = "x".repeat(6100);
+  const text = stamp(longContent, "https://example.com/long", "2026-05-13T09:00:00.000Z", "high", "hackernews");
+  const parsed = parsedEnvelope(text);
+
+  assert.equal(parsed.content.length, 6000);
+  assert.equal(parsed.content, "x".repeat(6000));
+});
+
+test("parseFreshContextJson parses valid blocks and rejects missing or malformed blocks", () => {
+  const text = stamp("Parse me", "https://example.com/parse", "2026-05-13T09:00:00.000Z", "high", "hackernews");
+
+  assert.ok(parseFreshContextJson(text));
+  assert.equal(parseFreshContextJson("plain text without JSON block"), null);
+  assert.equal(parseFreshContextJson("[FRESHCONTEXT_JSON]\nnot json\n[/FRESHCONTEXT_JSON]"), null);
+});
+
+test("replaceFreshContextJson replaces only the JSON block and can add cache metadata", () => {
+  const text = stamp("Cache me", "https://example.com/cache", "2026-05-13T09:00:00.000Z", "high", "hackernews");
+  const parsed = parsedEnvelope(text);
+  const replaced = replaceFreshContextJson(text, {
+    ...parsed,
+    cache: {
+      status: "hit",
+      cached_at: "2026-05-13T09:01:00.000Z",
+      cache_age_seconds: 12,
+      ttl_seconds: 900,
+      key_version: "v2",
+    },
+  });
+  const reparsed = parsedEnvelope(replaced);
+
+  assert.match(replaced, /\[FRESHCONTEXT\]/);
+  assert.match(replaced, /Source: https:\/\/example\.com\/cache/);
+  assert.equal(reparsed.freshcontext.source_url, parsed.freshcontext.source_url);
+  assert.equal(reparsed.cache?.status, "hit");
+  assert.equal(reparsed.cache?.key_version, "v2");
+});
+
+test("isUncacheableContent blocks only empty and hard error output at this layer", () => {
+  assert.equal(isUncacheableContent(""), true);
+  assert.equal(isUncacheableContent("   "), true);
+  assert.equal(isUncacheableContent("[ERROR] upstream failed"), true);
+  assert.equal(isUncacheableContent("plain text without JSON block"), false);
+});
+
+test("analyzeCompositeContent distinguishes all-unavailable, partial, and non-section content", () => {
+  assert.deepEqual(analyzeCompositeContent([
+    "## First",
+    "[Unavailable: timeout]",
+    "",
+    "## Second",
+    "Error",
+  ].join("\n")), {
+    allUnavailable: true,
+    hasPartialFailures: true,
+  });
+
+  assert.deepEqual(analyzeCompositeContent([
+    "## First",
+    "[Unavailable: timeout]",
+    "",
+    "## Second",
+    "Useful result",
+  ].join("\n")), {
+    allUnavailable: false,
+    hasPartialFailures: true,
+  });
+
+  assert.deepEqual(analyzeCompositeContent("Useful single-adapter content\n[Unavailable: not a section]"), {
+    allUnavailable: false,
+    hasPartialFailures: false,
+  });
+});

--- a/worker/src/freshcontextEnvelope.ts
+++ b/worker/src/freshcontextEnvelope.ts
@@ -1,0 +1,108 @@
+import { calculateFreshnessScore, freshnessLabel } from "./intelligence.js";
+
+export function parseFreshContextJson(text: string): Record<string, any> | null {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  if (!match) return null;
+  try { return JSON.parse(match[1]) as Record<string, any>; } catch { return null; }
+}
+
+export function replaceFreshContextJson(text: string, structured: Record<string, any>): string {
+  const block = [
+    "[FRESHCONTEXT_JSON]",
+    JSON.stringify(structured, null, 2),
+    "[/FRESHCONTEXT_JSON]",
+  ].join("\n");
+  return text.replace(/\[FRESHCONTEXT_JSON\]\s*[\s\S]*?\s*\[\/FRESHCONTEXT_JSON\]/, block);
+}
+
+export function isUncacheableContent(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return true;
+  if (/^\[ERROR\]/i.test(trimmed)) return true;
+  return false;
+}
+
+export function analyzeCompositeContent(content: string): { allUnavailable: boolean; hasPartialFailures: boolean } {
+  const lines = content.split(/\r?\n/);
+  let inSection = false;
+  let hasUsefulContent = false;
+  let hasUnavailableContent = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("## ")) { inSection = true; continue; }
+    if (!inSection || !trimmed) continue;
+    if (trimmed.startsWith("[Unavailable:") || trimmed === "Error") {
+      hasUnavailableContent = true;
+    } else {
+      hasUsefulContent = true;
+    }
+  }
+  return {
+    allUnavailable: inSection && !hasUsefulContent,
+    hasPartialFailures: inSection && hasUnavailableContent,
+  };
+}
+
+export function looksLikeFailedAdapterContent(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) return true;
+  if (/^\[(?:error|security)\]/i.test(trimmed)) return true;
+  if (/^(?:error|failed|upstream|timeout)\b/i.test(trimmed)) return true;
+  const meaningful = trimmed.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  if (!meaningful.length) return true;
+  const failureLines = meaningful.filter(line =>
+    /\b(?:error|failed|failure|timeout|401|403|404|429|5\d\d)\b/i.test(line)
+  );
+  return failureLines.length === meaningful.length;
+}
+
+export function stamp(
+  content: string,
+  url: string,
+  date: string | null,
+  confidence: "high" | "medium" | "low",
+  adapter: string
+): string {
+  const retrieved_at = new Date().toISOString();
+  const failedContent = looksLikeFailedAdapterContent(content);
+  const safeDate = failedContent ? null : date;
+  const safeConfidence = failedContent ? "low" : confidence;
+  const freshness_score = calculateFreshnessScore(safeDate, retrieved_at, adapter);
+  const sliced = content.slice(0, 6000);
+
+  const scoreLine = freshness_score !== null
+    ? `Score: ${freshness_score}/100 (${freshnessLabel(freshness_score)})`
+    : `Score: unknown`;
+
+  const textEnvelope = [
+    "[FRESHCONTEXT]",
+    `Source: ${url}`,
+    `Published: ${safeDate ?? "unknown"}`,
+    `Retrieved: ${retrieved_at}`,
+    `Confidence: ${safeConfidence}`,
+    scoreLine,
+    "---",
+    sliced,
+    "[/FRESHCONTEXT]",
+  ].join("\n");
+
+  const structured = {
+    freshcontext: {
+      source_url:           url,
+      content_date:         safeDate,
+      retrieved_at,
+      freshness_confidence: safeConfidence,
+      freshness_score,
+      adapter,
+    },
+    content: sliced,
+  };
+
+  const jsonBlock = [
+    "[FRESHCONTEXT_JSON]",
+    JSON.stringify(structured, null, 2),
+    "[/FRESHCONTEXT_JSON]",
+  ].join("\n");
+
+  return `${textEnvelope}\n\n${jsonBlock}`;
+}

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -3,7 +3,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod";
 import { synthesizeBriefing as generateAIBriefing } from "./synthesize.js";
-import { scoreSignal, parseStoredProfile, semanticFingerprint, isDuplicate, applyDecay, RT_EXPIRY_FLOOR, calculateFreshnessScore, freshnessLabel } from "./intelligence.js";
+import { scoreSignal, parseStoredProfile, semanticFingerprint, isDuplicate, applyDecay, RT_EXPIRY_FLOOR } from "./intelligence.js";
+import {
+  analyzeCompositeContent,
+  isUncacheableContent,
+  parseFreshContextJson,
+  replaceFreshContextJson,
+  stamp,
+} from "./freshcontextEnvelope.js";
 
 const SERVICE_VERSION = "0.3.17";
 const SERVICE_UA = `freshcontext-mcp/${SERVICE_VERSION} (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)`;
@@ -299,53 +306,6 @@ async function buildCacheKey(toolName: string, input: unknown): Promise<CacheKey
   };
 }
 
-function parseFreshContextJson(text: string): Record<string, any> | null {
-  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
-  if (!match) return null;
-  try { return JSON.parse(match[1]) as Record<string, any>; } catch { return null; }
-}
-
-function replaceFreshContextJson(text: string, structured: Record<string, any>): string {
-  const block = [
-    "[FRESHCONTEXT_JSON]",
-    JSON.stringify(structured, null, 2),
-    "[/FRESHCONTEXT_JSON]",
-  ].join("\n");
-  return text.replace(/\[FRESHCONTEXT_JSON\]\s*[\s\S]*?\s*\[\/FRESHCONTEXT_JSON\]/, block);
-}
-
-function isUncacheableContent(text: string): boolean {
-  const trimmed = text.trim();
-  if (!trimmed) return true;
-  if (/^\[ERROR\]/i.test(trimmed)) return true;
-  return false;
-}
-
-// Analyses raw composite content (the unstamped body before [FRESHCONTEXT] wrapping).
-// Only composite tools use "## Section" headers; single-adapter outputs do not, so
-// inSection never flips true for them and both flags stay false.
-function analyzeCompositeContent(content: string): { allUnavailable: boolean; hasPartialFailures: boolean } {
-  const lines = content.split(/\r?\n/);
-  let inSection = false;
-  let hasUsefulContent = false;
-  let hasUnavailableContent = false;
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("## ")) { inSection = true; continue; }
-    if (!inSection || !trimmed) continue;
-    // Matches [Unavailable: reason] (section() helper) and bare "Error" (landscape tool).
-    if (trimmed.startsWith("[Unavailable:") || trimmed === "Error") {
-      hasUnavailableContent = true;
-    } else {
-      hasUsefulContent = true;
-    }
-  }
-  return {
-    allUnavailable: inSection && !hasUsefulContent,
-    hasPartialFailures: inSection && hasUnavailableContent,
-  };
-}
-
 async function getFromCache(
   kv: KVNamespace,
   toolName: string,
@@ -521,70 +481,6 @@ function errResponse(message: string, status: number): Response {
   return new Response(JSON.stringify({ error: message }), {
     status, headers: { "Content-Type": "application/json" },
   });
-}
-
-function looksLikeFailedAdapterContent(raw: string): boolean {
-  const trimmed = raw.trim();
-  if (!trimmed) return true;
-  if (/^\[(?:error|security)\]/i.test(trimmed)) return true;
-  if (/^(?:error|failed|upstream|timeout)\b/i.test(trimmed)) return true;
-  const meaningful = trimmed.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-  if (!meaningful.length) return true;
-  const failureLines = meaningful.filter(line =>
-    /\b(?:error|failed|failure|timeout|401|403|404|429|5\d\d)\b/i.test(line)
-  );
-  return failureLines.length === meaningful.length;
-}
-
-function stamp(
-  content: string,
-  url: string,
-  date: string | null,
-  confidence: "high" | "medium" | "low",
-  adapter: string
-): string {
-  const retrieved_at = new Date().toISOString();
-  const failedContent = looksLikeFailedAdapterContent(content);
-  const safeDate = failedContent ? null : date;
-  const safeConfidence = failedContent ? "low" : confidence;
-  const freshness_score = calculateFreshnessScore(safeDate, retrieved_at, adapter);
-  const sliced = content.slice(0, 6000);
-
-  const scoreLine = freshness_score !== null
-    ? `Score: ${freshness_score}/100 (${freshnessLabel(freshness_score)})`
-    : `Score: unknown`;
-
-  const textEnvelope = [
-    "[FRESHCONTEXT]",
-    `Source: ${url}`,
-    `Published: ${safeDate ?? "unknown"}`,
-    `Retrieved: ${retrieved_at}`,
-    `Confidence: ${safeConfidence}`,
-    scoreLine,
-    "---",
-    sliced,
-    "[/FRESHCONTEXT]",
-  ].join("\n");
-
-  const structured = {
-    freshcontext: {
-      source_url:           url,
-      content_date:         safeDate,
-      retrieved_at,
-      freshness_confidence: safeConfidence,
-      freshness_score,
-      adapter,
-    },
-    content: sliced,
-  };
-
-  const jsonBlock = [
-    "[FRESHCONTEXT_JSON]",
-    JSON.stringify(structured, null, 2),
-    "[/FRESHCONTEXT_JSON]",
-  ].join("\n");
-
-  return `${textEnvelope}\n\n${jsonBlock}`;
 }
 
 // ─── withCache helper ─────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary

Extracts the Worker-local FreshContext envelope/cache helper logic into a pure Worker helper module so the behavior can be tested directly before any Core-backed Worker migration.

## Changes

- Adds `worker/src/freshcontextEnvelope.ts`
- Moves Worker-local helper definitions out of `worker/src/worker.ts`
- Updates `worker/src/worker.ts` to import the extracted helpers
- Adds `tests/workerEnvelope.test.ts`
- Updates `npm test` to include Worker envelope helper tests

## Extracted helpers

- `looksLikeFailedAdapterContent`
- `stamp`
- `parseFreshContextJson`
- `replaceFreshContextJson`
- `isUncacheableContent`
- `analyzeCompositeContent`

## Scope

This is a behavior-preserving helper extraction only.

It does not:
- replace Worker stamping with Core stamping
- change Pass 6 cache behavior
- change cache key generation
- change `getFromCache`, `setInCache`, or `withCache` semantics
- change runtime `/mcp` transport guards
- modify `worker/src/intelligence.ts`
- modify `src/server.ts`
- modify feeds, adapters, D1, cron, or Ops Pulse
- deploy production

## Preserved Worker behavior

- `Published: unknown`
- Worker max content length `6000`
- existing `[FRESHCONTEXT_JSON]` shape
- additive cache metadata injection
- all-unavailable / partial-failure composite cache rules

## Validation

- `npm run build`
- `npm test` — 33 passed, 1 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `git diff --check`
