### PR TITLE
Pass 7 Phase 3F-C1 — Core envelope Worker-compatible options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/core/envelope.ts
+++ b/src/core/envelope.ts
@@ -1,4 +1,4 @@
-import type { FreshContext, AdapterResult, ExtractOptions } from "./types.js";
+import type { FreshContext, AdapterResult, ExtractOptions, EnvelopeFormatOptions } from "./types.js";
 import { calculateFreshnessScore, scoreLabel } from "./decay.js";
 import { looksLikeFailedAdapterContent } from "./guards.js";
 
@@ -42,10 +42,12 @@ export function toStructuredJSON(ctx: FreshContext): object {
   };
 }
 
-export function formatForLLM(ctx: FreshContext): string {
+export function formatForLLM(ctx: FreshContext, options: EnvelopeFormatOptions = {}): string {
+  const publishedLabel = options.publishedLabel ?? "Published";
+  const unknownDateText = options.unknownDateText ?? "Publish date: unknown";
   const dateInfo = ctx.content_date
-    ? `Published: ${ctx.content_date}`
-    : "Publish date: unknown";
+    ? `${publishedLabel}: ${ctx.content_date}`
+    : unknownDateText;
 
   const scoreLine = ctx.freshness_score !== null
     ? `Score: ${ctx.freshness_score}/100 (${scoreLabel(ctx.freshness_score)})`

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,6 +7,7 @@ export type {
   FreshContext,
   ExtractOptions,
   AdapterResult,
+  EnvelopeFormatOptions,
   SignalConfidence,
   FreshSignal,
   RankedSignal,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,6 +24,11 @@ export interface AdapterResult {
   freshness_confidence: "high" | "medium" | "low";
 }
 
+export interface EnvelopeFormatOptions {
+  unknownDateText?: string;
+  publishedLabel?: string;
+}
+
 export type SignalConfidence = "high" | "medium" | "low";
 
 export interface FreshSignal {

--- a/tests/coreEnvelopeOptions.test.ts
+++ b/tests/coreEnvelopeOptions.test.ts
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatForLLM,
+  stampFreshness,
+  toStructuredJSON,
+} from "../src/core/index.js";
+import type { EnvelopeFormatOptions } from "../src/core/index.js";
+
+const SOURCE_URL = "https://example.com/core-options";
+const CONTENT_DATE = "2026-05-13T09:00:00.000Z";
+const ADAPTER = "github";
+
+function parseCoreJson(text: string): {
+  freshcontext: {
+    source_url: string;
+    content_date: string | null;
+    retrieved_at: string;
+    freshness_confidence: "high" | "medium" | "low";
+    freshness_score: number | null;
+    adapter: string;
+  };
+  content: string;
+} {
+  const match = text.match(/\[FRESHCONTEXT_JSON\]\s*([\s\S]*?)\s*\[\/FRESHCONTEXT_JSON\]/);
+  assert.ok(match, "expected FreshContext JSON block");
+  return JSON.parse(match[1]);
+}
+
+test("Core envelope defaults preserve current missing-date text and max length", () => {
+  const ctx = stampFreshness({
+    raw: "x".repeat(8100),
+    content_date: null,
+    freshness_confidence: "medium",
+  }, { url: SOURCE_URL }, ADAPTER);
+  const text = formatForLLM(ctx);
+
+  assert.match(text, /Publish date: unknown/);
+  assert.doesNotMatch(text, /Published: unknown/);
+  assert.equal(ctx.content.length, 8000);
+});
+
+test("Core can emit Worker-compatible missing-date text when explicitly requested", () => {
+  const options: EnvelopeFormatOptions = {
+    unknownDateText: "Published: unknown",
+  };
+  const ctx = stampFreshness({
+    raw: "Missing date body",
+    content_date: null,
+    freshness_confidence: "medium",
+  }, { url: SOURCE_URL, maxLength: 8000 }, ADAPTER);
+  const text = formatForLLM(ctx, options);
+
+  assert.match(text, /Published: unknown/);
+  assert.doesNotMatch(text, /Publish date: unknown/);
+});
+
+test("Core can cap content at the Worker target length through maxLength", () => {
+  const ctx = stampFreshness({
+    raw: "y".repeat(7001),
+    content_date: CONTENT_DATE,
+    freshness_confidence: "high",
+  }, { url: SOURCE_URL, maxLength: 6000 }, ADAPTER);
+
+  assert.equal(ctx.content.length, 6000);
+  assert.equal(ctx.content, "y".repeat(6000));
+});
+
+test("Core JSON shape remains unchanged when envelope formatting options are used", () => {
+  const ctx = stampFreshness({
+    raw: "Structured body",
+    content_date: CONTENT_DATE,
+    freshness_confidence: "high",
+  }, { url: SOURCE_URL, maxLength: 8000 }, ADAPTER);
+  const text = formatForLLM(ctx, { unknownDateText: "Published: unknown" });
+  const parsed = parseCoreJson(text);
+  const structured = toStructuredJSON(ctx);
+
+  assert.deepEqual(parsed, structured);
+  assert.deepEqual(Object.keys(parsed), ["freshcontext", "content"]);
+  assert.deepEqual(Object.keys(parsed.freshcontext), [
+    "source_url",
+    "content_date",
+    "retrieved_at",
+    "freshness_confidence",
+    "freshness_score",
+    "adapter",
+  ]);
+});
+
+test("Core failure downgrade behavior remains unchanged with formatting options", () => {
+  const ctx = stampFreshness({
+    raw: "[Error] upstream timeout",
+    content_date: CONTENT_DATE,
+    freshness_confidence: "high",
+  }, { url: SOURCE_URL, maxLength: 8000 }, ADAPTER);
+  const text = formatForLLM(ctx, { unknownDateText: "Published: unknown" });
+  const parsed = parseCoreJson(text);
+
+  assert.equal(ctx.content_date, null);
+  assert.equal(ctx.freshness_confidence, "low");
+  assert.equal(ctx.freshness_score, null);
+  assert.match(text, /Published: unknown/);
+  assert.equal(parsed.freshcontext.content_date, null);
+  assert.equal(parsed.freshcontext.freshness_confidence, "low");
+  assert.equal(parsed.freshcontext.freshness_score, null);
+});


### PR DESCRIPTION
﻿## Summary

Adds additive Core envelope formatting options so Core can produce Worker-compatible envelope text when explicitly requested, without changing default Core behavior or Worker behavior.

## Changes

- Adds `EnvelopeFormatOptions`
- Adds optional Core envelope formatting controls:
  - `unknownDateText`
  - `publishedLabel`
- Updates `formatForLLM(ctx, options?)`
- Adds `tests/coreEnvelopeOptions.test.ts`
- Updates `npm test` to include the new test file

## Scope

This is Core-options only.

It does not:

- modify `worker/src/worker.ts`
- modify `worker/src/freshcontextEnvelope.ts`
- modify `worker/src/intelligence.ts`
- modify `src/server.ts`
- change Pass 6 cache behavior
- change runtime `/mcp` transport behavior
- change feeds or adapters
- add cache metadata support to Core
- migrate Worker stamping to Core
- deploy production

## Proof

- Default Core output remains unchanged: missing dates still emit `Publish date: unknown`
- Worker-compatible text is opt-in: `Published: unknown`
- Core can cap content at `6000` through `maxLength`
- Core JSON shape remains unchanged
- Failure downgrade behavior remains unchanged

## Validation

- `npm run build`
- `npm test` — 45 passed, 1 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `git diff --check`
- hidden-character scan — no output
