### PR TITLE
Pass 7 Phase 3H — document Core/Worker boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ R_t = R_0 · e^(−λt)
 
 That's the whole fix. No model swap. No re-embedding. No re-indexing. The layer drops onto whatever retrieval pipeline you already have.
 
-**The layer is the product.** The 21 tools shipped with this repo are reference implementations demonstrating compatibility — useful, but commodity. The DAR engine, the freshness envelope, and the FreshContext Specification are the moat.
+**The layer is the product.** The 21 tools shipped with this repo are reference adapters demonstrating compatibility — useful, but commodity. The DAR engine, the freshness envelope, and the FreshContext Specification are the moat.
 
 ---
 
@@ -62,7 +62,17 @@ Confidence: high
 
 **When** it was retrieved. **Where** it came from. **How confident** we are the date is accurate.
 
-The FreshContext Specification v1.1 is published as an open standard under MIT licence. Any tool, agent, or system that wraps retrieved data in this envelope is FreshContext-compatible. → [Read the spec](./FRESHCONTEXT_SPEC.md) · [Read the methodology](./METHODOLOGY.md)
+The FreshContext Specification v1.2 is published as an open standard under MIT licence. Any tool, agent, or system that wraps retrieved data in this envelope is FreshContext-compatible. → [Read the spec](./FRESHCONTEXT_SPEC.md) · [Read the methodology](./METHODOLOGY.md)
+
+---
+
+## Architecture boundary
+
+FreshContext Core is the reusable engine. It owns freshness scoring, envelope formatting, failure guards, shared types, rank/explain primitives, and the context-conditioned utility primitive.
+
+MCP is one interface over Core. Claude Desktop is supported, but not required. The 21 MCP tools in this repo are reference adapters and a live interface for using the system.
+
+The production Cloudflare Worker now uses Core-backed envelope generation. Worker-specific concerns remain outside Core: MCP transport, runtime guards, KV cache policy, cache metadata injection, JSON parse/replace cache helpers, D1 feeds, cron, rate limiting, and Store/feed scoring/provenance.
 
 ---
 
@@ -258,13 +268,14 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
 ## Roadmap
 
-- [x] FreshContext Specification v1.1 published (MIT, open standard)
+- [x] FreshContext Specification v1.2 published (MIT, open standard)
 - [x] DAR engine with proprietary λ constants (v0.3.17)
 - [x] Ha-Pri audit signatures on every signal
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`
 - [x] METHODOLOGY.md — formal IP and engineering documentation
 - [x] 21 reference tools across intelligence, competitive research, market data, and composites
+- [x] Core-backed envelope generation shared by npm/MCP and the Cloudflare Worker
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
 - [x] Listed on official MCP Registry, Apify Store, npm
 - [x] GitHub Actions CI/CD — auto-publish on every push


### PR DESCRIPTION
﻿## Summary

Documents the current FreshContext Core/Worker boundary after Pass 7 envelope convergence.

## Changes

- Updates README specification wording from v1.1 to v1.2
- Describes Core as the reusable engine
- Clarifies MCP as one interface over Core
- Clarifies Claude Desktop is supported, not required
- Describes the 21 MCP tools as reference adapters and a live interface
- Documents that Worker envelope generation is now Core-backed
- Documents that cache/runtime/platform behavior remains Worker-owned
- Adds roadmap note for Core-backed envelope generation shared by npm/MCP and Cloudflare Worker

## Scope

Documentation only.

It does not:

- change runtime code
- change Worker code
- change Core implementation code
- change tests
- change Pass 6 cache behavior
- change MCP transport behavior
- change feeds or adapters
- deploy production

## Validation

- `npm run build`
- `npm test` — 51 passed, 1 skipped
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `git diff --check`
- hidden-character scan on README — no output
