### PR TITLE
Math Spine Phase 2-B — clarify Ha-Pri v1 integrity boundary

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -229,13 +229,17 @@ Every signal stored in a FreshContext Store/Ledger deployment carries a `ha_pri_
 SHA-256( result_id + ":" + content_hash + ":" + "FRESHCONTEXT_DAR_V1" )
 ```
 
-This signature serves three purposes:
+In Ha-Pri v1, this signature is a provenance stamp and audit reference for stored signals. It binds the result ID, the current content hash, and the engine version. It is not yet a full tamper-enforcement system: the current `content_hash` source is the existing rolling `result_hash`, and signatures are not recomputed on read to reject modified rows.
 
-1. **Tamper detection** — the signature binds the content hash to the result ID and the engine version. Any modification to the stored content would invalidate the signature.
-2. **Provenance chain** — every row in the `scrape_results` table is cryptographically linked to the moment it was scored by the DAR engine.
-3. **Licensing audit** — when FreshContext data is provided to a third party under licence, the `ha_pri_sig` column provides an immutable record of exactly what was delivered and when.
+Ha-Pri v1 serves three purposes:
 
-Ha-Pri is the provenance/integrity layer, while DAR and context-conditioned utility are the ranking/scoring layer.
+1. **Provenance reference** — the signature links the stored result ID, content hash, and DAR engine version.
+2. **Scoring trace** — every row in the `scrape_results` table carries a reference to the moment it was scored by the DAR engine.
+3. **Licensing audit** — when FreshContext data is provided to a third party under licence, the `ha_pri_sig` column provides an audit reference for what was delivered and when.
+
+Future Ha-Pri v2 may add canonical content SHA-256, stronger canonicalization, and explicit verification/rejection on read. That hardening is separate from the current v1 provenance stamp.
+
+Ha-Pri v1 is the provenance layer and the foundation for a stronger integrity layer, while DAR and context-conditioned utility are the ranking/scoring layer.
 
 ### 3.2 D1 Historical Ledger
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Beyond the per-call envelope, the production FreshContext deployment exposes a c
 GET /v1/intel/feed/:profile_id?limit=20&min_rt=0
 ```
 
-Every signal is stamped with `base_score`, `rt_score`, `entropy_level` (low / stable / high), `ha_pri_sig` (SHA-256 provenance), `semantic_fingerprint` (cross-adapter dedup), and `published_at`. Ready for direct LLM or agent consumption — no synthesis required.
+Every signal is stamped with `base_score`, `rt_score`, `entropy_level` (low / stable / high), `ha_pri_sig` (Ha-Pri v1 SHA-256 provenance reference), `semantic_fingerprint` (cross-adapter dedup), and `published_at`. Ready for direct LLM or agent consumption — no synthesis required.
 
 Production endpoint: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
@@ -259,7 +259,7 @@ The reference implementation runs on Cloudflare's global edge:
 - **D1 database** — 18 watched queries running on 6-hour cron with relevancy scoring
 - **KV-backed rate limiting** — 60 req/min per IP across all edge nodes
 - **Defensive valves** — clock-skew rejection (5min tolerance), hard floor at R_t<5, lazy decay at read time
-- **Provenance** — Ha-Pri SHA-256 audit signatures on every signal
+- **Provenance** — Ha-Pri v1 SHA-256 provenance stamps on stored signals; hard tamper enforcement is a future Ha-Pri v2 path
 - **Schema migrations** — promise-gated, idempotent, run on first request after deploy
 
 Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
@@ -270,7 +270,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
 - [x] FreshContext Specification v1.2 published (MIT, open standard)
 - [x] DAR engine with proprietary λ constants (v0.3.17)
-- [x] Ha-Pri audit signatures on every signal
+- [x] Ha-Pri v1 provenance signatures on stored signals
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`
 - [x] METHODOLOGY.md — formal IP and engineering documentation
@@ -278,6 +278,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 - [x] Core-backed envelope generation shared by npm/MCP and the Cloudflare Worker
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
 - [x] Listed on official MCP Registry, Apify Store, npm
+- [ ] Ha-Pri v2 hardened canonical content hash verification
 - [x] GitHub Actions CI/CD — auto-publish on every push
 - [ ] Webhook triggers — push high-entropy signals on threshold
 - [ ] Dashboard — React frontend for the D1 intelligence pipeline


### PR DESCRIPTION
﻿Clarifies Ha-Pri v1 as a provenance stamp / audit reference rather than hard tamper enforcement.

Documents that current Ha-Pri v1:
- binds result ID, current content hash, and engine version
- is generated/stored/returned
- is not yet recomputed on read to reject tampering
- currently depends on the existing rolling result_hash

Also notes future Ha-Pri v2 direction:
- canonical content SHA-256
- explicit verification/rejection
- additive hardening, not immediate migration

No runtime behavior changes.
No Worker changes.
No schema changes.
No deploy required.
