### PR TITLE
Core API public contract stabilization

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -1,0 +1,105 @@
+# FreshContext Core API
+
+FreshContext Core is the reusable engine layer in the current integrated MCP/Core package. It owns envelope creation, freshness scoring, failure honesty, rank/explain primitives, and the experimental context-utility primitive.
+
+MCP, Worker HTTP, future REST, and future CLI/SDK surfaces should use Core as the contract center instead of redefining freshness or envelope behavior per host.
+
+## Stable Public Core API
+
+Import stable Core functions from:
+
+```ts
+import {
+  calculateFreshnessScore,
+  formatForLLM,
+  looksLikeFailedAdapterContent,
+  scoreLabel,
+  stampFreshness,
+  toStructuredJSON,
+} from "./src/core/index.js";
+```
+
+### Envelope
+
+- `stampFreshness(result, options, adapter)` creates a `FreshContext` object from adapter output.
+- `formatForLLM(ctx, options?)` renders the text envelope and trailing structured JSON block.
+- `toStructuredJSON(ctx)` returns the machine-readable FreshContext JSON shape.
+
+### Scoring
+
+- `calculateFreshnessScore(content_date, retrieved_at, adapter)` returns a freshness score from `0..100`, or `null` when the content date cannot be trusted.
+- `scoreLabel(score)` maps a numeric freshness score to a human-readable label.
+
+### Guards
+
+- `looksLikeFailedAdapterContent(raw)` detects empty, security, timeout, and error-like adapter output so failed content is not stamped as fresh high-confidence context.
+
+### Stable Types
+
+- `FreshContext`
+- `AdapterResult`
+- `ExtractOptions`
+- `EnvelopeFormatOptions`
+- `SignalConfidence`
+
+These types describe the stable envelope and adapter result contract.
+
+## Public Ranking Primitives
+
+The ranking primitives are public, but consumers should treat their score scales carefully:
+
+- `rankSignal(signal, options?)`
+- `rankSignals(signals, options?)`
+- `explainSignal(rankedSignalLike)`
+- `FreshSignal`
+- `RankedSignal`
+- `RankOptions`
+
+Score scales:
+
+- `semantic_score`: normalized `0..1`
+- `final_score`: normalized `0..1`
+- `freshness_score`: FreshContext freshness score `0..100`, or `null`
+
+Ranking combines semantic relevance and freshness into a deterministic order. It does not own retrieval, embedding, vector search, storage, or host-specific scoring policy.
+
+## Experimental Utility Primitive
+
+The context-conditioned utility primitive is pure and tested, but it is not production-wired into MCP ranking, Worker feeds, Store scoring, or runtime behavior.
+
+Experimental exports:
+
+- `calculateContextUtility`
+- `ContextUtilityStatus`
+- `ContextUtilityInput`
+- `ContextUtilityResult`
+
+These are part of Math Spine Phase 1. Treat them as experimental until a later math integration pass decides how they should affect production ranking or external APIs.
+
+## Internal, Policy, and Compatibility Exports
+
+- `clampScore` is an internal ranking helper. It is currently exported for tests and utility use, but it should not be presented as a primary buyer-facing API.
+- `LAMBDA` is the current policy constant table used by freshness scoring. It documents the reference decay policy, but it is not a buyer-facing tuning API.
+
+Compatibility lanes should remain:
+
+- `src/types.ts` re-exports legacy adapter types from Core.
+- `src/tools/freshnessStamp.ts` re-exports envelope helpers for older MCP/npm import paths.
+
+These lanes protect existing imports while Core becomes the center. Do not remove them until downstream imports have been migrated intentionally.
+
+## What Core Does Not Own
+
+Core does not own:
+
+- MCP transport
+- Cloudflare runtime behavior
+- KV cache policy
+- Cache metadata injection
+- D1, feed, or cron behavior
+- Store/feed scoring and provenance persistence
+- Ha-Pri v2
+- Hosted dashboard, API, deployment, or runtime concerns
+
+Hosts may wrap Core outputs with their own transport, cache, session, rate-limit, or persistence metadata, but they should not fork the Core envelope and freshness contract without an explicit compatibility reason.
+

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  calculateContextUtility,
+  calculateFreshnessScore,
+  explainSignal,
+  formatForLLM,
+  looksLikeFailedAdapterContent,
+  rankSignal,
+  rankSignals,
+  scoreLabel,
+  stampFreshness,
+  toStructuredJSON,
+} from "../src/core/index.js";
+import type {
+  AdapterResult,
+  ContextUtilityInput,
+  ContextUtilityResult,
+  EnvelopeFormatOptions,
+  ExtractOptions,
+  FreshContext,
+  FreshSignal,
+  RankedSignal,
+  RankOptions,
+} from "../src/core/index.js";
+
+test("public Core API imports compile and callable functions remain available", () => {
+  const result: AdapterResult = {
+    raw: "Public Core API contract content",
+    content_date: "2026-05-24T12:00:00.000Z",
+    freshness_confidence: "high",
+  };
+  const options: ExtractOptions = {
+    url: "https://example.com/core-api-contract",
+    maxLength: 8000,
+  };
+  const formatOptions: EnvelopeFormatOptions = {
+    unknownDateText: "Published: unknown",
+  };
+
+  const ctx: FreshContext = stampFreshness(result, options, "hackernews");
+  const structured = toStructuredJSON(ctx) as { content: string };
+  const text = formatForLLM(ctx, formatOptions);
+  const freshnessScore = calculateFreshnessScore(
+    result.content_date,
+    ctx.retrieved_at,
+    "hackernews"
+  );
+
+  assert.equal(structured.content, ctx.content);
+  assert.match(text, /\[FRESHCONTEXT\]/);
+  assert.equal(typeof freshnessScore, "number");
+  assert.equal(typeof scoreLabel(freshnessScore), "string");
+  assert.equal(looksLikeFailedAdapterContent(result.raw), false);
+  assert.equal(looksLikeFailedAdapterContent("[Error] upstream timeout"), true);
+});
+
+test("public ranking and utility imports compile and remain callable", () => {
+  const signal: FreshSignal = {
+    source: "https://example.com/ranked",
+    source_type: "hackernews",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: "2026-05-24T13:00:00.000Z",
+    semantic_score: 0.85,
+    content: "Relevant public Core ranking contract content",
+  };
+  const rankOptions: RankOptions = {
+    now: "2026-05-24T13:00:00.000Z",
+    defaultSourceType: "hackernews",
+  };
+
+  const ranked: RankedSignal = rankSignal(signal, rankOptions);
+  const rankedSignals: RankedSignal[] = rankSignals([signal], rankOptions);
+
+  assert.equal(rankedSignals.length, 1);
+  assert.equal(typeof ranked.reason, "string");
+  assert.equal(explainSignal(ranked), ranked.reason);
+
+  const utilityInput: ContextUtilityInput = {
+    contextualRelevance: 80,
+    lambda: 0.01,
+    ageHours: 24,
+    dateConfidence: "high",
+    status: "success",
+  };
+  const utility: ContextUtilityResult = calculateContextUtility(utilityInput);
+
+  assert.equal(typeof utility.score, "number");
+});
+


### PR DESCRIPTION
## Summary

Documents the FreshContext Core public API contract and adds a focused public import-surface test before REST, SDK, CLI, or additional integrations.

## Changes

- Adds `docs/CORE_API.md`
- Adds `tests/coreApiContract.test.ts`
- Updates `npm test` to include the Core API contract test

## Core API categories documented

- Stable public Core API
- Public ranking primitives
- Experimental utility exports
- Internal / policy exports
- Compatibility lanes
- What Core does not own

## Scope

This is documentation and contract-test only.

It does not:

- change Core implementation
- change Worker behavior
- change adapters
- change feeds
- change runtime transport
- change cache behavior
- change package version
- deploy production
- publish npm
- start REST, SDK, CLI, Ha-Pri v2, or math integration work

## Validation

- `npm run build`
- `npm test` � 60 passed, 1 skipped
- `npm run smoke:stdio` � 21 tools
- `git diff --check`
- hidden-character scan � no matches
- trailing-whitespace scan � no matches