### PR TITLE
Math Spine Phase 3-B — pure Ha-Pri v2 Core helpers

### DIFF
--- a/docs/HA_PRI_V2_DESIGN.md
+++ b/docs/HA_PRI_V2_DESIGN.md
@@ -1,7 +1,7 @@
 # Ha-Pri v2 Design
 
-Status: design only
-Phase: Math Spine Phase 3-A
+Status: design + pure Core helper
+Phase: Math Spine Phase 3-A / 3-B
 Runtime impact: none
 
 ## Purpose
@@ -10,7 +10,7 @@ Ha-Pri v2 is an additive provenance-hardening model for FreshContext Store/Ledge
 
 The goal is to keep Ha-Pri v1 readable while designing a stronger future signature that binds a row to canonical content, semantic identity, source metadata, timestamps, and engine version.
 
-This document does not implement Ha-Pri v2, change the D1 schema, change Worker write paths, migrate old rows, add HMAC secrets, or alter production scoring.
+Phase 3-B adds pure Core helper functions and deterministic tests for the v2 model. Production Store wiring remains future work. This document does not change the D1 schema, change Worker write paths, migrate old rows, add HMAC secrets, or alter production scoring.
 
 ## Current Ha-Pri v1 Audit
 
@@ -165,7 +165,7 @@ Recommended rules:
 2. Normalize line endings to `\n`.
 3. Trim trailing whitespace on each line.
 4. Preserve meaningful internal whitespace.
-5. Normalize null or missing fields to explicit sentinel text, such as `<null>`.
+5. Normalize null or missing optional fields to the literal string `"null"`.
 6. Use stable field order.
 7. Use ISO-8601 timestamps where available.
 8. Do not include fields whose values change during read-time verification unless they are explicitly part of the signed record.
@@ -176,16 +176,20 @@ For future implementation, canonicalization should live in a pure helper with de
 ## Proposed v2 Formula
 
 ```text
-ha_pri_sig_v2 = SHA-256(
-  "FRESHCONTEXT_HA_PRI_V2" + "\n" +
-  result_id + "\n" +
-  canonical_content_sha256 + "\n" +
-  semantic_fingerprint_sha256 + "\n" +
-  adapter + "\n" +
-  published_at + "\n" +
-  scraped_at + "\n" +
-  engine_version
-)
+ha_pri_sig_v2 = SHA-256(signingPayload)
+```
+
+Where `signingPayload` is exactly:
+
+```text
+FRESHCONTEXT_HA_PRI_V2
+result_id=<resultId>
+canonical_content_sha256=<canonicalContentSha256>
+semantic_fingerprint_sha256=<semanticFingerprintSha256>
+adapter=<adapter>
+published_at=<publishedAt-or-null>
+retrieved_at=<retrievedAt-or-null>
+engine_version=<engineVersion>
 ```
 
 ### Field Meaning
@@ -196,8 +200,10 @@ ha_pri_sig_v2 = SHA-256(
 - `semantic_fingerprint_sha256`: cryptographic digest of semantic identity fields
 - `adapter`: source adapter name
 - `published_at`: source/content publication timestamp, or explicit null sentinel
-- `scraped_at` / `retrieved_at`: collection timestamp
+- `retrieved_at`: retrieval or collection timestamp, or explicit null sentinel
 - `engine_version`: scoring/signature engine version
+
+Store/Ledger systems may map `scraped_at` to the v2 `retrieved_at` signing field.
 
 ## Verification Model
 
@@ -271,4 +277,3 @@ This design does not:
 - reject rows in production
 - publish npm
 - deploy the Worker
-

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,12 @@ export { stampFreshness, toStructuredJSON, formatForLLM } from "./envelope.js";
 export { explainSignal } from "./explain.js";
 export { rankSignals, rankSignal, clampScore } from "./rank.js";
 export { calculateContextUtility } from "./utility.js";
+export {
+  canonicalizeHaPriContent,
+  sha256Hex,
+  calculateHaPriV2,
+  verifyHaPriV2,
+} from "./provenance.js";
 export type {
   FreshContext,
   ExtractOptions,
@@ -16,4 +22,9 @@ export type {
   ContextUtilityStatus,
   ContextUtilityInput,
   ContextUtilityResult,
+  HaPriV2Input,
+  HaPriV2Material,
+  HaPriV2Result,
+  HaPriVerificationStatus,
+  HaPriV2VerificationResult,
 } from "./types.js";

--- a/src/core/provenance.ts
+++ b/src/core/provenance.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import type {
+  HaPriV2Input,
+  HaPriV2Result,
+  HaPriV2VerificationResult,
+} from "./types.js";
+
+const HA_PRI_V2_VERSION = "FRESHCONTEXT_HA_PRI_V2" as const;
+const NULL_SENTINEL = "null";
+
+function fieldValue(value: string | null | undefined): string {
+  return value ?? NULL_SENTINEL;
+}
+
+export function canonicalizeHaPriContent(input: string): string {
+  return input
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n");
+}
+
+export function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+export function calculateHaPriV2(input: HaPriV2Input): HaPriV2Result {
+  const canonicalContentSha256 = sha256Hex(canonicalizeHaPriContent(input.rawContent));
+  const semanticFingerprintSha256 = sha256Hex(fieldValue(input.semanticFingerprint));
+  const resultId = fieldValue(input.resultId);
+  const adapter = fieldValue(input.adapter);
+  const publishedAt = fieldValue(input.publishedAt);
+  const retrievedAt = fieldValue(input.retrievedAt);
+  const engineVersion = fieldValue(input.engineVersion);
+
+  const signingPayload = [
+    HA_PRI_V2_VERSION,
+    `result_id=${resultId}`,
+    `canonical_content_sha256=${canonicalContentSha256}`,
+    `semantic_fingerprint_sha256=${semanticFingerprintSha256}`,
+    `adapter=${adapter}`,
+    `published_at=${publishedAt}`,
+    `retrieved_at=${retrievedAt}`,
+    `engine_version=${engineVersion}`,
+  ].join("\n");
+
+  return {
+    version: HA_PRI_V2_VERSION,
+    resultId,
+    canonicalContentSha256,
+    semanticFingerprintSha256,
+    adapter,
+    publishedAt,
+    retrievedAt,
+    engineVersion,
+    signingPayload,
+    haPriSigV2: sha256Hex(signingPayload),
+  };
+}
+
+export function verifyHaPriV2(
+  input: HaPriV2Input,
+  actualSig: string | null | undefined
+): HaPriV2VerificationResult {
+  if (actualSig === null || actualSig === undefined || actualSig.trim() === "") {
+    return {
+      status: "unknown",
+      expected: null,
+      actual: actualSig ?? null,
+      reasons: ["missing ha_pri_sig_v2; verification status unknown"],
+    };
+  }
+
+  const expected = calculateHaPriV2(input).haPriSigV2;
+  if (actualSig === expected) {
+    return {
+      status: "valid",
+      expected,
+      actual: actualSig,
+      reasons: [],
+    };
+  }
+
+  return {
+    status: "invalid",
+    expected,
+    actual: actualSig,
+    reasons: ["stored ha_pri_sig_v2 did not match recomputed signature"],
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -83,3 +83,38 @@ export interface ContextUtilityResult {
   status: ContextUtilityStatus;
   reasons: string[];
 }
+
+export interface HaPriV2Input {
+  resultId: string;
+  rawContent: string;
+  semanticFingerprint?: string | null;
+  adapter: string;
+  publishedAt?: string | null;
+  retrievedAt?: string | null;
+  engineVersion: string;
+}
+
+export interface HaPriV2Material {
+  version: "FRESHCONTEXT_HA_PRI_V2";
+  resultId: string;
+  canonicalContentSha256: string;
+  semanticFingerprintSha256: string;
+  adapter: string;
+  publishedAt: string;
+  retrievedAt: string;
+  engineVersion: string;
+  signingPayload: string;
+}
+
+export interface HaPriV2Result extends HaPriV2Material {
+  haPriSigV2: string;
+}
+
+export type HaPriVerificationStatus = "valid" | "invalid" | "unknown";
+
+export interface HaPriV2VerificationResult {
+  status: HaPriVerificationStatus;
+  expected: string | null;
+  actual: string | null;
+  reasons: string[];
+}

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -9,17 +9,33 @@ import {
   toStructuredJSON,
   formatForLLM,
   calculateContextUtility,
+  canonicalizeHaPriContent,
+  sha256Hex,
+  calculateHaPriV2,
+  verifyHaPriV2,
 } from "../src/core/index.js";
 import type {
   AdapterResult,
   ContextUtilityResult,
   ExtractOptions,
   FreshContext,
+  HaPriV2Input,
+  HaPriV2Result,
 } from "../src/core/index.js";
 
 function hoursAgo(hours: number): string {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
 }
+
+const BASE_HA_PRI_V2_INPUT: HaPriV2Input = {
+  resultId: "sr_test_123",
+  rawContent: "Show HN: FreshContext\nhttps://example.com/freshcontext\nPublished: 2026-05-24",
+  semanticFingerprint: "abc123semantic",
+  adapter: "hackernews",
+  publishedAt: "2026-05-24T10:00:00.000Z",
+  retrievedAt: "2026-05-24T11:00:00.000Z",
+  engineVersion: "freshcontext-0.3.17",
+};
 
 test("Core exports decay policy constants for current adapters", () => {
   assert.equal(typeof LAMBDA.hackernews, "number");
@@ -260,4 +276,133 @@ test("Core context utility public export is available from src/core/index.ts", (
   assert.equal(typeof calculateContextUtility, "function");
   assert.equal(typeof utility.score, "number");
   assert.equal(Array.isArray(utility.reasons), true);
+});
+
+test("Core Ha-Pri v2 signature is deterministic and exposes signing material", () => {
+  const first: HaPriV2Result = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const second = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+
+  assert.deepEqual(first, second);
+  assert.equal(first.version, "FRESHCONTEXT_HA_PRI_V2");
+  assert.equal(first.resultId, BASE_HA_PRI_V2_INPUT.resultId);
+  assert.equal(first.adapter, BASE_HA_PRI_V2_INPUT.adapter);
+  assert.equal(first.publishedAt, BASE_HA_PRI_V2_INPUT.publishedAt);
+  assert.equal(first.retrievedAt, BASE_HA_PRI_V2_INPUT.retrievedAt);
+  assert.equal(first.engineVersion, BASE_HA_PRI_V2_INPUT.engineVersion);
+  assert.match(first.canonicalContentSha256, /^[a-f0-9]{64}$/);
+  assert.match(first.semanticFingerprintSha256, /^[a-f0-9]{64}$/);
+  assert.match(first.haPriSigV2, /^[a-f0-9]{64}$/);
+  assert.equal(first.haPriSigV2, sha256Hex(first.signingPayload));
+});
+
+test("Core Ha-Pri v2 signing payload uses stable field order", () => {
+  const result = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const expectedPayload = [
+    "FRESHCONTEXT_HA_PRI_V2",
+    `result_id=${BASE_HA_PRI_V2_INPUT.resultId}`,
+    `canonical_content_sha256=${result.canonicalContentSha256}`,
+    `semantic_fingerprint_sha256=${result.semanticFingerprintSha256}`,
+    `adapter=${BASE_HA_PRI_V2_INPUT.adapter}`,
+    `published_at=${BASE_HA_PRI_V2_INPUT.publishedAt}`,
+    `retrieved_at=${BASE_HA_PRI_V2_INPUT.retrievedAt}`,
+    `engine_version=${BASE_HA_PRI_V2_INPUT.engineVersion}`,
+  ].join("\n");
+
+  assert.equal(result.signingPayload, expectedPayload);
+});
+
+test("Core Ha-Pri v2 detects content tampering through content hash and signature", () => {
+  const original = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const tampered = calculateHaPriV2({
+    ...BASE_HA_PRI_V2_INPUT,
+    rawContent: `${BASE_HA_PRI_V2_INPUT.rawContent}\nTampered line`,
+  });
+
+  assert.notEqual(tampered.canonicalContentSha256, original.canonicalContentSha256);
+  assert.notEqual(tampered.haPriSigV2, original.haPriSigV2);
+});
+
+test("Core Ha-Pri v2 binds result ID, engine version, adapter, and timestamps", () => {
+  const original = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const changedResultId = calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, resultId: "sr_other" });
+  const changedEngine = calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, engineVersion: "freshcontext-0.3.18" });
+  const changedAdapter = calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, adapter: "reddit" });
+  const changedPublished = calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, publishedAt: "2026-05-24T12:00:00.000Z" });
+  const changedRetrieved = calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, retrievedAt: "2026-05-24T12:00:00.000Z" });
+
+  assert.notEqual(changedResultId.haPriSigV2, original.haPriSigV2);
+  assert.notEqual(changedEngine.haPriSigV2, original.haPriSigV2);
+  assert.notEqual(changedAdapter.haPriSigV2, original.haPriSigV2);
+  assert.notEqual(changedPublished.haPriSigV2, original.haPriSigV2);
+  assert.notEqual(changedRetrieved.haPriSigV2, original.haPriSigV2);
+});
+
+test("Core Ha-Pri v2 binds semantic fingerprint and handles absent fields explicitly", () => {
+  const original = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const changedSemantic = calculateHaPriV2({
+    ...BASE_HA_PRI_V2_INPUT,
+    semanticFingerprint: "different-semantic-fingerprint",
+  });
+  const missingFields = calculateHaPriV2({
+    ...BASE_HA_PRI_V2_INPUT,
+    semanticFingerprint: null,
+    publishedAt: null,
+    retrievedAt: undefined,
+  });
+
+  assert.notEqual(changedSemantic.semanticFingerprintSha256, original.semanticFingerprintSha256);
+  assert.notEqual(changedSemantic.haPriSigV2, original.haPriSigV2);
+  assert.equal(missingFields.semanticFingerprintSha256, sha256Hex("null"));
+  assert.match(missingFields.signingPayload, /published_at=null/);
+  assert.match(missingFields.signingPayload, /retrieved_at=null/);
+});
+
+test("Core Ha-Pri v2 canonicalizes line endings and trailing whitespace", () => {
+  const crlf = "Alpha  \r\nBeta\t\rGamma";
+  const lf = "Alpha\nBeta\nGamma";
+
+  assert.equal(canonicalizeHaPriContent(crlf), lf);
+  assert.equal(
+    calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, rawContent: crlf }).canonicalContentSha256,
+    calculateHaPriV2({ ...BASE_HA_PRI_V2_INPUT, rawContent: lf }).canonicalContentSha256
+  );
+});
+
+test("Core Ha-Pri v2 verification returns valid, invalid, and unknown", () => {
+  const calculated = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const valid = verifyHaPriV2(BASE_HA_PRI_V2_INPUT, calculated.haPriSigV2);
+  const invalid = verifyHaPriV2(
+    { ...BASE_HA_PRI_V2_INPUT, rawContent: `${BASE_HA_PRI_V2_INPUT.rawContent}\nchanged` },
+    calculated.haPriSigV2
+  );
+  const unknownNull = verifyHaPriV2(BASE_HA_PRI_V2_INPUT, null);
+  const unknownBlank = verifyHaPriV2(BASE_HA_PRI_V2_INPUT, " ");
+
+  assert.equal(valid.status, "valid");
+  assert.equal(valid.expected, calculated.haPriSigV2);
+  assert.equal(valid.actual, calculated.haPriSigV2);
+  assert.deepEqual(valid.reasons, []);
+
+  assert.equal(invalid.status, "invalid");
+  assert.equal(invalid.actual, calculated.haPriSigV2);
+  assert.match(invalid.reasons.join(" "), /did not match/);
+
+  assert.equal(unknownNull.status, "unknown");
+  assert.equal(unknownNull.expected, null);
+  assert.equal(unknownNull.actual, null);
+  assert.match(unknownNull.reasons.join(" "), /missing/);
+
+  assert.equal(unknownBlank.status, "unknown");
+  assert.equal(unknownBlank.actual, " ");
+});
+
+test("Core Ha-Pri v2 public exports are available from src/core/index.ts", () => {
+  const result = calculateHaPriV2(BASE_HA_PRI_V2_INPUT);
+  const verified = verifyHaPriV2(BASE_HA_PRI_V2_INPUT, result.haPriSigV2);
+
+  assert.equal(typeof canonicalizeHaPriContent, "function");
+  assert.equal(typeof sha256Hex, "function");
+  assert.equal(typeof calculateHaPriV2, "function");
+  assert.equal(typeof verifyHaPriV2, "function");
+  assert.equal(verified.status, "valid");
 });

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   calculateContextUtility,
+  calculateHaPriV2,
   calculateFreshnessScore,
   explainSignal,
   formatForLLM,
@@ -20,6 +21,8 @@ import type {
   ExtractOptions,
   FreshContext,
   FreshSignal,
+  HaPriV2Input,
+  HaPriV2Result,
   RankedSignal,
   RankOptions,
 } from "../src/core/index.js";
@@ -86,5 +89,18 @@ test("public ranking and utility imports compile and remain callable", () => {
   const utility: ContextUtilityResult = calculateContextUtility(utilityInput);
 
   assert.equal(typeof utility.score, "number");
+
+  const haPriInput: HaPriV2Input = {
+    resultId: "sr_public_contract",
+    rawContent: "Public Core provenance contract content",
+    semanticFingerprint: "public-core-fingerprint",
+    adapter: "hackernews",
+    publishedAt: "2026-05-24T12:00:00.000Z",
+    retrievedAt: "2026-05-24T13:00:00.000Z",
+    engineVersion: "freshcontext-0.3.17",
+  };
+  const haPri: HaPriV2Result = calculateHaPriV2(haPriInput);
+
+  assert.match(haPri.haPriSigV2, /^[a-f0-9]{64}$/);
 });
 


### PR DESCRIPTION
Adds pure Core helper functions and tests for additive Ha-Pri v2 provenance hardening.

Includes:
- `canonicalizeHaPriContent`
- `sha256Hex`
- `calculateHaPriV2`
- `verifyHaPriV2`
- Ha-Pri v2 public types
- deterministic signature tests
- tamper-detection tests
- public Core API contract coverage
- design doc alignment with the implemented labelled signing payload

No runtime behavior changes.
No Worker changes.
No D1 schema changes.
No Store migration.
No feed/Ops changes.
No deploy.
No npm publish.
Ha-Pri v1 remains unchanged.