### PR TITLE
Math Spine Phase 3-C0 — clarify Ha-Pri v1 provenance boundary

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -233,9 +233,11 @@ In Ha-Pri v1, this signature is a provenance stamp and audit reference for store
 
 Ha-Pri v1 serves three purposes:
 
-1. **Provenance reference** — the signature links the stored result ID, content hash, and DAR engine version.
-2. **Scoring trace** — every row in the `scrape_results` table carries a reference to the moment it was scored by the DAR engine.
-3. **Licensing audit** — when FreshContext data is provided to a third party under licence, the `ha_pri_sig` column provides an audit reference for what was delivered and when.
+1. **Provenance reference** — the signature binds the result ID, current rolling content hash, and engine/version marker so the stored signal can be audited against the v1 formula.
+2. **Scoring lineage** — the signature records the scoring/signature formula used when the row was written.
+3. **Licensing / audit reference** — when FreshContext data is provided to a third party under licence, the `ha_pri_sig` column gives a stable reference for what was stored and delivered.
+
+Ha-Pri v1 is not hard tamper enforcement. It is not recomputed on read, it signs the existing rolling result_hash (`result_hash`) rather than canonical content SHA-256, and it does not reject rows. Ha-Pri v2 is the planned/additive path for stronger verification.
 
 Future Ha-Pri v2 may add canonical content SHA-256, stronger canonicalization, and explicit verification/rejection on read. That hardening is separate from the current v1 provenance stamp.
 
@@ -248,7 +250,7 @@ The `scrape_results` table functions as a **Contextual Ledger** — not merely a
 This Store/Ledger methodology is not required for basic FreshContext-compatible envelope implementations. It is the methodology for systems that persist recurring signals and want auditability over time.
 
 Key properties of the ledger:
-- Every row is immutable once written (no UPDATE operations on scored rows)
+- Scored signal material is treated as immutable once written; consumption metadata such as `is_new` may be updated
 - Every row carries a `scraped_at` timestamp with second precision
 - Every row carries a `published_at` date extracted from content (where available)
 - The ledger accumulates continuously at 6-hour intervals regardless of active user sessions
@@ -350,7 +352,7 @@ For technical integrators, auditors, and future platform partners:
 
 3. **The Semantic Fingerprinting Method** — the three-field normalisation and SHA-256 fingerprinting approach for cross-adapter deduplication.
 
-4. **The Ha-Pri Audit Signature scheme** — the provenance binding method that makes the historical ledger tamper-evident.
+4. **The Ha-Pri Audit Signature scheme** — the provenance stamp and audit reference that binds stored row material to the current v1 formula; stronger tamper-evidence is the future additive v2 path.
 
 5. **The Store / Ledger design** — support for recurring watched queries, historical signal accumulation, D1-backed storage, and time-series auditability.
 

--- a/RISKS.md
+++ b/RISKS.md
@@ -81,12 +81,12 @@ If `targets` or `skills` columns contain malformed JSON, `safeParse` falls back 
 
 - **Mitigation if needed:** Skip insertion when `R_0 == 0`.
 
-### 11. `ha_pri_sig` is integrity, not authentication
+### 11. `ha_pri_sig` is a provenance stamp, not authentication
 
-`PROVENANCE_SALT = "FRESHCONTEXT_DAR_V1"` is hardcoded in a public repo. Anyone with the source can forge a valid `ha_pri_sig` for any `(resultId, contentHash)` pair. The signature proves the pair was hashed together at some point — it does not prove "scored by this engine".
+`PROVENANCE_SALT = "FRESHCONTEXT_DAR_V1"` is hardcoded in a public repo. Anyone with the source can compute a valid `ha_pri_sig` for any `(resultId, contentHash)` pair. The signature is a provenance stamp / audit reference for the v1 formula — it does not authenticate the row's source or provide hard tamper enforcement.
 
 - **Where:** intelligence.ts:195
-- **Why this matters:** METHODOLOGY.md describes the signature as proving provenance. That's accurate against accidental tampering, not against an adversary. If a customer ever needs cryptographic provenance, the salt would need to move to a secret binding (env var) and signatures would need to be reissued.
+- **Why this matters:** Ha-Pri v1 signs the current rolling `result_hash` and is not recomputed on read. If a customer ever needs authentication or row rejection, that belongs in the additive Ha-Pri v2 path with stronger content hashing and an explicit verification model.
 
 ### 12. Trailing-slash URLs do not collapse
 

--- a/worker/src/intelligence.ts
+++ b/worker/src/intelligence.ts
@@ -232,8 +232,8 @@ const PROVENANCE_SALT = "FRESHCONTEXT_DAR_V1";
 
 /**
  * Generate a SHA-256 audit signature for a signal.
- * This is the ha_pri_sig — the digital fingerprint proving the signal
- * was scored by this engine at this point in time.
+ * This is the ha_pri_sig: a provenance stamp / audit reference recording
+ * the v1 engine/version formula used when the row was scored.
  *
  * Uses Web Crypto API (available natively in Cloudflare Workers).
  */


### PR DESCRIPTION
Clarifies Ha-Pri v1 wording so current docs and comments do not overclaim hard tamper enforcement.

Changes:
- Reframes Ha-Pri v1 as a provenance stamp / audit reference.
- Clarifies v1 binds result ID, rolling result hash/content hash, and `FRESHCONTEXT_DAR_V1`.
- Notes v1 is not recomputed on read and does not reject rows.
- Clarifies scored signal material is treated as immutable, while consumption metadata like `is_new` may update.
- Softens Worker comments without changing implementation.

Validation:
- `npm run build` passed
- `npm test` passed: 68 passed / 1 skipped
- `npm run smoke:stdio` passed: 0.3.17, 21 tools
- `cd worker && npx tsc --noEmit` passed
- `git diff --check` passed

No runtime behavior changes.
No Worker logic changes.
No D1 schema changes.
No Ha-Pri v2 wiring.
No deploy.
No npm publish.