### PR TITLE
Math Spine Phase 3-C — Ha-Pri v2 developer fixture

### DIFF
--- a/docs/HA_PRI_V2_DESIGN.md
+++ b/docs/HA_PRI_V2_DESIGN.md
@@ -10,7 +10,7 @@ Ha-Pri v2 is an additive provenance-hardening model for FreshContext Store/Ledge
 
 The goal is to keep Ha-Pri v1 readable while designing a stronger future signature that binds a row to canonical content, semantic identity, source metadata, timestamps, and engine version.
 
-Phase 3-B adds pure Core helper functions and deterministic tests for the v2 model. Production Store wiring remains future work. This document does not change the D1 schema, change Worker write paths, migrate old rows, add HMAC secrets, or alter production scoring.
+Phase 3-B adds pure Core helper functions and deterministic tests for the v2 model. Phase 3-C adds `examples/ha-pri-v2-example.ts`, a deterministic developer fixture showing `calculateHaPriV2` and `verifyHaPriV2` returning valid, invalid, and unknown verification states. Production Store wiring remains future work. This document does not change the D1 schema, change Worker write paths, migrate old rows, add HMAC secrets, or alter production scoring.
 
 ## Current Ha-Pri v1 Audit
 

--- a/examples/ha-pri-v2-example.ts
+++ b/examples/ha-pri-v2-example.ts
@@ -1,0 +1,37 @@
+// FreshContext Ha-Pri v2 developer fixture.
+//
+// This example demonstrates the pure Core helper only. It does not touch D1,
+// change Worker behavior, deploy Ha-Pri v2, or wire v2 into production output.
+// It shows the three verification states: valid, invalid, and unknown.
+
+import { calculateHaPriV2, verifyHaPriV2 } from "../src/core/index.js";
+
+const input = {
+  resultId: "result_demo_001",
+  rawContent: "FreshContext demo signal\r\nStatus: usable  ",
+  semanticFingerprint: "freshcontext-demo|https://example.com/demo|2026-05-25",
+  adapter: "demo",
+  publishedAt: "2026-05-25T08:00:00.000Z",
+  retrievedAt: "2026-05-25T09:00:00.000Z",
+  engineVersion: "freshcontext-ha-pri-v2-demo",
+};
+
+const result = calculateHaPriV2(input);
+const valid = verifyHaPriV2(input, result.haPriSigV2);
+const invalid = verifyHaPriV2(
+  { ...input, rawContent: `${input.rawContent}\nTampered: true` },
+  result.haPriSigV2
+);
+const unknown = verifyHaPriV2(input, undefined);
+
+console.log(JSON.stringify({
+  canonicalContentSha256: result.canonicalContentSha256,
+  semanticFingerprintSha256: result.semanticFingerprintSha256,
+  signingPayload: result.signingPayload,
+  haPriSigV2: result.haPriSigV2,
+  verification: {
+    valid: valid.status,
+    invalid: invalid.status,
+    unknown: unknown.status,
+  },
+}, null, 2));

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dev": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
+    "example:ha-pri-v2": "tsx examples/ha-pri-v2-example.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
     "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts"
   },


### PR DESCRIPTION
Adds a deterministic developer-facing fixture for the pure Ha-Pri v2 Core helpers.

Includes:
- `examples/ha-pri-v2-example.ts`
- `npm run example:ha-pri-v2`
- narrow Phase 3-C note in `docs/HA_PRI_V2_DESIGN.md`

The example demonstrates:
- `calculateHaPriV2`
- `verifyHaPriV2`
- valid verification
- invalid verification after tampering
- unknown verification for missing signature
- canonical content hash
- semantic fingerprint hash
- labelled signing payload
- v2 signature output

Validation:
- `npm run build` passed
- `npm test` passed: 68 passed / 1 skipped
- `npm run smoke:stdio` passed: 0.3.17, 21 tools
- `cd worker && npx tsc --noEmit` passed
- `git diff --check` passed
- `npm run example:ha-pri-v2` passed

No Worker changes.
No D1 schema changes.
No runtime behavior changes.
No feed/Ops changes.
No deploy.
No npm publish.
No Ha-Pri v2 production wiring.