### PR TITLE
Legal/Security L1 — tighten public claims and package hygiene

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -35,6 +35,17 @@ ROADMAP.md
 USAGE.md
 TIME_CHECK_README.md
 
+# Sale, diligence, and outreach planning docs are not npm package material
+docs/ACQUISITION_READINESS_CHECKLIST.md
+docs/BUYER_DEMO_SCRIPT.md
+docs/BUYER_SHARE_BUNDLE.md
+docs/FIRST_10_TARGETS.md
+docs/FRESHCONTEXT_MATH_SPINE_REVIEW.md
+docs/IP_INVENTORY.md
+docs/STRATEGIC_BRIEF.md
+docs/TARGET_LIST_AND_OUTREACH_PLAN.md
+docs/TRUST_ROADMAP.md
+
 # Repo-only smoke/demo/development helpers
 scripts/
 demo/

--- a/FRESHCONTEXT_SPEC.md
+++ b/FRESHCONTEXT_SPEC.md
@@ -10,9 +10,9 @@ The FreshContext Specification defines a standard envelope format for AI-retriev
 
 It exists to solve one problem: **AI models present stale data with the same confidence as fresh data, and users have no way to tell the difference.**
 
-> **Live demonstration:** [freshcontext-mcp.gimmanuel73.workers.dev/demo](https://freshcontext-mcp.gimmanuel73.workers.dev/demo) — same model, same query, two completely different answers. Only the temporal layer changed.
+> **Illustrative demonstration:** [freshcontext-mcp.gimmanuel73.workers.dev/demo](https://freshcontext-mcp.gimmanuel73.workers.dev/demo) — same model, same query, different answers from different ranked context. The demo shows how FreshContext treats freshness signals.
 
-FreshContext fixes this by wrapping every piece of retrieved content in a structured envelope that carries three guarantees:
+FreshContext addresses this by wrapping retrieved content in a structured envelope that carries three explicit properties:
 
 1. **When** the data was retrieved (exact ISO 8601 timestamp)
 2. **Where** it came from (canonical source URL)

--- a/USAGE.md
+++ b/USAGE.md
@@ -106,7 +106,7 @@ Use extract_govcontracts with url "Palantir"
 ```
 Use search_jobs with query "AI engineer" location "remote" max_age_days 7
 ```
-*Fresh job listings only. Every result has a freshness badge — never apply to a closed role again.*
+*Fresh job listings with freshness badges, so stale or closed roles are easier to spot before you act.*
 
 ```
 Use search_jobs with query "typescript developer" remote_only true
@@ -189,7 +189,7 @@ Use extract_scholar with url "https://scholar.google.com/scholar?q=AI+agent+grou
 2. Use extract_govcontracts with url "[target company]"
 3. Use extract_changelog with url "https://github.com/[target-company]/[repo]"
 ```
-*Fresh listings only + proof the company is growing + proof they're actively shipping.*
+*Fresh listings plus signals that the company is growing and actively shipping.*
 
 #### Track a competitor
 ```
@@ -233,7 +233,7 @@ Track portfolio companies, find signals before they're obvious, monitor competit
 ---
 
 ### Researchers & Academics
-Fresh papers from arXiv and Google Scholar, ranked by date. Never cite a paper without knowing exactly when it was published and retrieved.
+Fresh papers from arXiv and Google Scholar, ranked by date. Avoid citing a paper without checking when it was published and retrieved.
 
 **Key tools:** `extract_arxiv`, `extract_scholar`, `extract_hackernews`
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,21 +1,25 @@
-# FreshContext — Live Demo
+# FreshContext - Illustrative Demo
 
-> **Same model. Same retrieval set. Same query. Two completely different answers — because one of them remembered when its sources were written.**
+> **Same model. Same retrieval set. Same query. Two different answers, because one ranking path preserved source age and the other did not.**
 
-A 5-document demonstration of why semantic-only retrieval gives 2026 systems 2022 answers — and what it costs to fix it.
+A 5-document illustrative demo built from a mock retrieval set. It shows how FreshContext treats freshness signals; it is not a claim about current RAG best practice.
 
 ## What's in this folder
 
 | File | Purpose |
 |------|---------|
-| `index.html` | The shareable demo. Self-contained, no server needed. Open in any browser. |
+| `index.html` | The shareable demo page. Serve the folder locally or host it statically so `data.json` can load. |
 | `data.json` | The mock retrieval set (5 documents, mixed timestamps, semantic scores). |
-| `generate.mjs` | Calls the live Anthropic API to regenerate the two answers — proves they aren't hand-written. |
+| `generate.mjs` | Calls the live Anthropic API to regenerate the two answers for comparison. |
 | `README.md` | This file. |
 
 ## View the demo
 
-Open `index.html` in any browser. R<sub>t</sub> is computed live on page load, so the math stays current as documents age.
+Serve the folder with a local static server, then open the served page in a browser. The page fetches `data.json`, and some browsers block that fetch from `file://` URLs. R<sub>t</sub> is computed live on page load, so the math stays current as documents age.
+
+```bash
+npx serve .
+```
 
 To share it as a link:
 
@@ -23,9 +27,9 @@ To share it as a link:
 - **GitHub Pages:** push `demo/` to a `gh-pages` branch.
 - **Static host:** any S3, Netlify, or Vercel deploy works. No build step.
 
-## Verify the answers are real
+## Regenerate the illustrative answers
 
-The two answers in `index.html` are pre-baked. To prove they aren't hand-written, regenerate them with a real Claude API call:
+The two answers in `index.html` are pre-baked illustrative outputs. You can compare them with a live Claude API call:
 
 ```powershell
 # PowerShell
@@ -42,15 +46,15 @@ The script:
 
 1. Loads `data.json`
 2. Computes R<sub>t</sub> for every document
-3. Builds two prompts — one with the top-3 by R<sub>0</sub> (semantic), one with the top-3 by R<sub>t</sub> (decay-adjusted)
+3. Builds two prompts - one with the top-3 by R<sub>0</sub> (semantic), one with the top-3 by R<sub>t</sub> (decay-adjusted)
 4. Calls `claude-sonnet-4-6` for both
 5. Prints both answers side-by-side
 
-You'll see the same kind of divergence the demo shows. Different versions of Claude will phrase it differently, but the *direction* of the change is structurally guaranteed: whatever the top-3 says, that's what the model anchors on.
+You should see the same kind of divergence the demo shows: when the top context changes, the model's answer usually follows the context it was given.
 
 ## What this demonstrates
 
-- **It's not a model problem.** Claude isn't wrong in the baseline — it faithfully summarized stale context.
+- **It's not a model-certification claim.** The demo shows how a model can faithfully summarize stale context.
 - **It's not an embedding problem.** Cosine similarity scores were correct.
 - **It's a context-engineering problem.** Retrieval ranks correctly along one axis (semantic similarity) and ignores another axis that matters in production (temporal validity).
 

--- a/demo/data.json
+++ b/demo/data.json
@@ -41,7 +41,7 @@
       "title": "Late Chunking and Contextual Retrieval",
       "published_at": "2025-09-30T00:00:00Z",
       "base_score": 86,
-      "content": "Late chunking with embedding-aware boundaries (bge-late-chunk, jina-late) outperforms both fixed-size and semantic chunking. Combine with contextual retrieval per Anthropic's research for state-of-the-art accuracy. The fixed-size 1000-token recommendation from earlier guides is now considered a baseline at best.",
+      "content": "Late chunking with embedding-aware boundaries (bge-late-chunk, jina-late) outperforms both fixed-size and semantic chunking in this illustrative source. Combine with contextual retrieval per Anthropic's research for stronger retrieval grounding. The fixed-size 1000-token recommendation from earlier guides is now considered a baseline at best.",
       "why_high_semantic_score": "Same authoritative source as #1, strong keyword match, more recent."
     },
     {
@@ -69,11 +69,11 @@
       ],
       "outro": "This approach is widely confirmed by both authoritative documentation and community consensus.",
       "verdict_class": "bad",
-      "verdict_text": "⚠ This is 2022 advice. ada-002 is no longer SOTA. Fixed-size chunking has been superseded."
+      "verdict_text": "Illustrative freshness boundary: the older advice is treated as stale in this mock retrieval set."
     },
     "fresh": {
       "context_label": "2026 X post · 2025 LangChain blog · 2024 arXiv paper",
-      "intro": "In 2026, the current state-of-the-art is <strong>late chunking with embedding-aware boundaries</strong>:",
+      "intro": "In this illustrative 2026 scenario, the fresher context points toward <strong>late chunking with embedding-aware boundaries</strong>:",
       "bullets": [
         "Use late-chunking models like <span class=\"inline-code\">bge-late-chunk</span> or <span class=\"inline-code\">jina-late</span>",
         "Combine with <strong>contextual retrieval</strong> (per Anthropic's research) for SOTA accuracy",
@@ -82,7 +82,7 @@
       ],
       "outro": "Common 2026 production failure: teams still applying 2022-era tutorial recommendations.",
       "verdict_class": "good",
-      "verdict_text": "✓ Current as of May 2026. Reflects 2025–2026 consensus while preserving the 2024 empirical context."
+      "verdict_text": "Illustrative: this mock set is ranked as fresher as of May 2026. Verify real recommendations independently."
     }
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Most RAG pipelines fail because of time, not embeddings — FreshContext</title>
-<meta name="description" content="A 5-document demonstration of why semantic-only retrieval gives 2026 systems 2022 answers — and what it costs to fix it.">
+<title>FreshContext illustrative freshness demo</title>
+<meta name="description" content="An illustrative FreshContext demo showing how freshness metadata changes ranking before context reaches an AI system.">
 <style>
   :root {
     --bg: #fafaf7;
@@ -296,13 +296,14 @@
 
 <div class="wrap">
 
-  <div class="byline">FreshContext · A live demonstration · v1.0</div>
+  <div class="byline">FreshContext · Illustrative static demo · v1.0</div>
 
   <h1>Most RAG pipelines fail because of time, not embeddings.</h1>
-  <p class="lede">Same model. Same retrieval set. Same query. Two completely different answers — because one of them remembered when its sources were written.</p>
+  <p class="lede">Same model. Same mock retrieval set. Same query. Two different answers, because one ranking path preserved source age and the other did not.</p>
+  <p>This demo uses synthetic documents and simplified envelopes to show how FreshContext treats signals. It does not certify the documents, determine truth, or provide current technical advice.</p>
 
   <h2>The query</h2>
-  <p>A developer in 2026 asks an AI agent for current best practices. Five documents are retrieved by semantic similarity:</p>
+  <p>A developer in an illustrative 2026 scenario asks an AI agent for current best practices. Five mock documents are retrieved by semantic similarity:</p>
 
   <div class="query-box">
     <div class="label">Query</div>
@@ -310,7 +311,7 @@
   </div>
 
   <h2>The retrieval set</h2>
-  <p>Each document scored on pure semantic similarity to the query. Top result is a 2022 blog post — confidently written, dense keyword match, authoritative source.</p>
+  <p>Each mock document scored on pure semantic similarity to the query. The top result is an older, confidently written example with a dense keyword match.</p>
 
   <div id="docs"></div>
 
@@ -347,7 +348,7 @@
   </div>
 
   <h2>The answer that changes</h2>
-  <p>Both answers come from the same model with the same query. The only difference is which three documents the model saw at the top of the context window:</p>
+  <p>Both illustrative answers use the same query. The only difference is which three documents appear at the top of the context window:</p>
 
   <div id="regen-note-anchor"></div>
 
@@ -371,9 +372,9 @@
 
   <h2>What this is, and what it isn't</h2>
 
-  <p><strong>This isn't a model problem.</strong> The same model produced both answers. Claude wasn't wrong in the first version — it faithfully summarized what was put in front of it.</p>
+  <p><strong>This isn't a model-certification claim.</strong> The demo shows how a model can faithfully summarize stale context when that is what appears first.</p>
 
-  <p><strong>This isn't an embedding problem.</strong> The cosine similarity scores were correct. The 2022 blog really is semantically dense and well-written.</p>
+  <p><strong>This isn't an embedding benchmark.</strong> The mock cosine scores are intentionally plausible so the freshness signal can be isolated.</p>
 
   <p><strong>This is a context-engineering problem.</strong> Retrieval ranks correctly along one axis (semantic similarity) and ignores the other axis that matters in production (temporal validity). FreshContext adds the missing axis.</p>
 

--- a/docs/IP_INVENTORY.md
+++ b/docs/IP_INVENTORY.md
@@ -1,6 +1,6 @@
 # FreshContext IP Inventory
 
-This document is a practical diligence inventory for FreshContext acquisition, licensing, or IP assignment preparation. It is not legal or tax advice. It is intended to help organize what exists, what may transfer, what may be licensed, and what must be reviewed before buyer access.
+This document is a practical diligence inventory for FreshContext acquisition, licensing, or IP assignment preparation. It is not legal or tax advice. It is intended to help organize what exists, what may transfer, what may be licensed, and what must be reviewed before buyer access. Transaction structure, tax treatment, and IP assignment terms require professional legal/tax review.
 
 ## Assets included
 


### PR DESCRIPTION
Tightens public/legal/security-facing wording and package hygiene after a sale-safety audit.

Changes:
- softens over-strong public/demo/spec claims
- aligns wording with current implementation boundaries
- keeps Ha-Pri v1 as provenance/audit reference, not hard enforcement
- keeps Ha-Pri v2 as Core helper/fixture, not production Store wiring
- updates package ignore rules to keep private buyer/strategy/outreach material out of npm artifacts
- adds transaction-safe wording where relevant

Validation:
- npm run build
- npm test
- npm run smoke:stdio
- npm run example:ha-pri-v2
- worker typecheck
- git diff --check
- npm pack --dry-run

No runtime behavior changes.
No Worker changes.
No D1 schema changes.
No feed/Ops changes.
No deploy.
No npm publish.