### PR TITLE
Trust L2-A — add license and security policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Immanuel Gabriel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+FreshContext currently supports the active `freshcontext-mcp@0.3.x` package line.
+
+Please use the latest published `0.3.x` release when reporting a vulnerability, and include the exact package version, repository, transport, and environment involved.
+
+## Reporting A Vulnerability
+
+FreshContext accepts responsible security reports by email:
+
+- gimmanuel73@gmail.com
+
+Please do not post secrets, tokens, private logs, customer data, exploit payloads, or sensitive operational details in public GitHub issues.
+
+For a useful report, include:
+
+- affected repository or package
+- affected version or commit
+- reproduction steps
+- expected and observed behavior
+- security impact
+- whether the issue affects local MCP usage, hosted Worker usage, examples, docs, packaging, or another surface
+
+Public GitHub issues are fine for non-sensitive bugs, documentation mistakes, stale claims, build failures, and feature requests.
+
+## Scope Notes
+
+FreshContext does not currently offer a formal bug bounty program.
+
+Please do not send live production tokens, private Cloudflare logs, npm tokens, GitHub tokens, MCP registry tokens, customer data, or private account data. If a report requires sensitive evidence, describe the issue first by email so a safer exchange path can be agreed.
+
+This policy does not make claims of certification, compliance, guaranteed response time, or security warranty.


### PR DESCRIPTION
Adds root license and security policy for FreshContext MCP.

Includes:
- root MIT LICENSE aligned with package metadata
- SECURITY.md for responsible vulnerability reporting
- guidance not to post secrets/tokens/private logs publicly

Validation:
- npm run build
- npm test
- npm run smoke:stdio
- npm run example:ha-pri-v2
- Worker typecheck
- git diff --check
- npm pack --dry-run

No runtime changes.
No Worker/D1/schema changes.
No deploy.
No npm publish.