### PR TITLE
Trust L4 — dependency audit and npm advisory cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5938,9 +5938,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6913,9 +6913,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "typescript": "^5.4.0"
   },
   "overrides": {
-    "file-type": "21.3.4"
+    "file-type": "21.3.4",
+    "qs": "6.15.2",
+    "ws": "8.20.1"
   }
 }


### PR DESCRIPTION
Dependency/security/license hygiene pass for FreshContext MCP.

Changes:
- resolves the two known moderate npm advisories by pinning transitive `qs` and `ws` through the existing npm `overrides` block
- updates `package-lock.json` only for `qs` and `ws` resolved versions/integrities
- does not change direct dependency versions or package version

Advisory decision:
- `qs` moderate advisory entered through `@modelcontextprotocol/sdk -> express/body-parser -> qs`; patched to `6.15.2`
- `ws` moderate advisory entered through `apify -> ws`; patched to `8.20.1`
- both are production dependency paths in the local install/audit tree
- no `npm audit fix` was used

License inventory summary:
- MCP license inventory is broadly permissive: MIT, Apache-2.0, BSD, ISC, 0BSD, BlueOak, CC-BY-4.0, and related permissive variants
- one scanner-unknown package, `map-stream@0.1.0`, has an MIT-style license file but missing package license metadata; keep as a diligence note
- no GPL/AGPL/LGPL/MPL/EPL/CDDL/copyleft packages were reported by the scan

Package checks:
- `npm pack --dry-run --json` still produces 50 entries
- private buyer/outreach/docs, token files, backup SQL, registry local files, tarballs, and private data-room files remain excluded

Validation:
- `npm run build`
- `npm test`
- `npm run smoke:stdio`
- `npm run example:ha-pri-v2`
- Worker `npx tsc --noEmit`
- `git diff --check`
- `npm audit --omit=dev --json`
- `npm audit --json`
- `npm pack --dry-run --json`

Also inspected Ops Pulse, site, and profile:
- Ops Pulse npm audits clean, license inventory permissive, package dry-run clean
- site/profile have no package manifests; stale-claim scans clean

No deploy.
No npm publish.
No runtime code changes.
No Worker/D1/schema/feed/Ops behavior changes.
No secrets touched.