### PR TITLE
Trust L5 — notices, attribution, and release-integrity guidance

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,17 @@
+# FreshContext Notice
+
+FreshContext is the project and software package distributed from this repository:
+
+https://github.com/PrinceGabriel-lgtm/freshcontext-mcp
+
+FreshContext is licensed under the MIT License as stated in `LICENSE` and package metadata.
+
+Third-party dependencies retain their own licenses, notices, copyrights, and attribution requirements. FreshContext does not claim ownership of third-party packages, services, trademarks, APIs, registries, or data sources referenced by the project.
+
+Before any commercial transfer, sale, assignment, or packaged diligence review, rerun dependency and license inventory checks and review third-party attribution obligations with appropriate professional support.
+
+This notice does not grant trademark registration, partnership status, certification, compliance status, or rights in third-party names.
+
+Security reports and trust questions may be sent to:
+
+gimmanuel73@gmail.com

--- a/README.md
+++ b/README.md
@@ -296,6 +296,17 @@ If you're building something FreshContext-compatible, open an issue and we'll ad
 
 ---
 
+## Trust and security
+
+- [LICENSE](./LICENSE)
+- [SECURITY.md](./SECURITY.md)
+- [NOTICE.md](./NOTICE.md)
+- [TRADEMARKS.md](./TRADEMARKS.md)
+- [Dependency diligence notes](./docs/DEPENDENCY_DILIGENCE.md)
+- [Release integrity notes](./docs/RELEASE_INTEGRITY.md)
+
+---
+
 ## License
 
 MIT

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,9 @@
+# FreshContext Brand and Trademark Notice
+
+FreshContext is the product and project name used by the project owner for this software, documentation, examples, and related public materials.
+
+No mark registration claim is made in this repository. Any future trademark filing, transfer, assignment, or licensing question should be reviewed separately.
+
+Third-party names, marks, services, and platforms, including Cloudflare, npm, GitHub, Model Context Protocol, MCP, Apify, Claude, OpenAI, Anthropic, and other referenced ecosystems, belong to their respective owners.
+
+Use of third-party names in this repository is descriptive, interoperability-oriented, or reference-oriented. It does not imply endorsement, certification, sponsorship, partnership, or official affiliation unless explicitly stated by the relevant third party.

--- a/docs/DEPENDENCY_DILIGENCE.md
+++ b/docs/DEPENDENCY_DILIGENCE.md
@@ -1,0 +1,57 @@
+# FreshContext Dependency Diligence Notes
+
+This document records dependency and license diligence notes from the Trust L4/L5 cleanup. It is not legal advice and does not replace professional review for a serious transaction.
+
+## Current Audit Status
+
+As of Trust L5:
+
+- `npm audit --omit=dev`: clean.
+- `npm audit`: clean.
+- The previous moderate `qs` and `ws` advisories were resolved with narrow transitive overrides.
+- No direct dependency version changes were required.
+- No package version change was made.
+
+## Resolved Advisories
+
+`qs`
+
+- Previous severity: moderate.
+- Path: `@modelcontextprotocol/sdk -> express/body-parser -> qs`.
+- Resolution: pinned through npm `overrides` to `qs@6.15.2`.
+
+`ws`
+
+- Previous severity: moderate.
+- Path: `apify -> ws`.
+- Resolution: pinned through npm `overrides` to `ws@8.20.1`.
+
+## License Inventory Notes
+
+The Trust L4 license inventory was broadly permissive, including MIT, Apache-2.0, BSD variants, ISC, 0BSD, BlueOak-1.0.0, and similar permissive variants.
+
+No GPL, AGPL, LGPL, MPL, EPL, CDDL, or similar copyleft licenses were reported in the Trust L4 scan.
+
+`map-stream@0.1.0`
+
+- Scanner result: `UNKNOWN`.
+- Path observed during L4: transitive through `apify` / Crawlee-related dependencies.
+- Diligence note: package metadata appears incomplete, but the installed package includes an MIT-style license file.
+- Action: keep as a diligence note and recheck before any transaction.
+
+`caniuse-lite`
+
+- Scanner result: `CC-BY-4.0`.
+- Diligence note: preserve and review attribution requirements before any sale, assignment, bundled distribution, or diligence package.
+
+## Before Sale Negotiation
+
+- Rerun `npm audit --omit=dev`.
+- Rerun `npm audit`.
+- Rerun dependency license inventory.
+- Review scanner-unknown packages.
+- Review `caniuse-lite` attribution requirements.
+- Generate an SBOM if requested by a buyer, evaluator, or transaction advisor.
+- Review dependency and license posture with qualified counsel if a transaction becomes serious.
+
+Do not treat this document as a legal conclusion.

--- a/docs/RELEASE_INTEGRITY.md
+++ b/docs/RELEASE_INTEGRITY.md
@@ -1,0 +1,45 @@
+# FreshContext Release Integrity Notes
+
+This document describes release hardening practices for future FreshContext package and archive releases. It is a plan and checklist, not an implemented signing or SBOM system.
+
+## Before Publishing or Sharing a Package
+
+- Start from a clean working tree.
+- Confirm the package version intentionally matches the release plan.
+- Run `npm run build`.
+- Run `npm test`.
+- Run `npm run smoke:stdio`.
+- Run `npm run example:ha-pri-v2`.
+- Run `cd worker && npx tsc --noEmit`.
+- Run `npm audit --omit=dev`.
+- Run `npm audit`.
+- Run `npm pack --dry-run --json`.
+- Run a stale-claim scan across public docs and package-facing files.
+- Run a secret scan before sharing archives, diligence folders, or package artifacts.
+
+## Package Exclusion Checks
+
+Confirm release artifacts do not include:
+
+- `.env` files.
+- Tokens or local API key files.
+- MCP registry local credential files.
+- Cloudflare local state.
+- `backup.sql` or local database snapshots.
+- Private sale, buyer, target, outreach, or diligence documents.
+- Private data-room folders.
+- Local logs.
+- Old package tarballs.
+
+## Release Notes and Integrity Artifacts
+
+Future release hardening may include:
+
+- GitHub release notes for tagged releases.
+- Signed git tags, if signing is configured.
+- `SHA256SUMS` files for release artifacts.
+- SBOM generation for buyer or enterprise diligence.
+- npm provenance and signature review.
+- A documented token-rotation checklist for any maintainer or ownership transfer.
+
+Do not publish from a dirty working tree. Do not publish from an environment that exposes secrets in logs or command output.


### PR DESCRIPTION
Adds public trust documentation for notices, brand boundaries, dependency diligence, and release integrity.

Includes:
- `NOTICE.md` for project/license/third-party notice boundaries
- `TRADEMARKS.md` for brand and third-party name boundaries without registration claims
- `docs/DEPENDENCY_DILIGENCE.md` documenting the Trust L4 npm audit status, `qs`/`ws` advisory resolution, `map-stream` scanner-unknown note, and `caniuse-lite` attribution review note
- `docs/RELEASE_INTEGRITY.md` with future package/release hardening checklist
- compact README trust/security links

Validation:
- `npm run build`
- `npm test`
- `npm run smoke:stdio`
- `npm run example:ha-pri-v2`
- Worker `npx tsc --noEmit`
- `git diff --check`
- `npm audit --omit=dev`
- `npm audit`
- `npm pack --dry-run --json`
- false-claim string scan across the new trust docs

Package dry-run:
- includes the new trust docs
- excludes private sale/outreach/docs, token files, `.env`, `backup.sql`, registry local files, tarballs, and private data-room material

No runtime changes.
No Worker/D1/schema/feed/Ops changes.
No package version change.
No dependency changes.
No deploy.
No npm publish.
No secrets touched.