### PR TITLE
Math Spine Phase 3-D — guard future-dated Core freshness scoring

### DIFF
--- a/docs/FRESHCONTEXT_MATH_SPINE_REVIEW.md
+++ b/docs/FRESHCONTEXT_MATH_SPINE_REVIEW.md
@@ -216,15 +216,11 @@ Failure honesty:
 
 This prevents failed upstream calls from being represented as high-confidence fresh content.
 
-Important review issue:
+Future timestamp guard:
 
-Core envelope scoring currently uses:
+Core envelope scoring tolerates small clock skew but does not reward meaningfully future-dated content with a maximum freshness score. If `content_date` is more than 5 minutes after `retrieved_at`, Core returns `freshness_score: null`; stamped envelopes also downgrade confidence to `low`.
 
-```text
-hours = max(0, retrieved - published)
-```
-
-This means meaningfully future-dated content can still score as maximally fresh in the simple envelope path. There is an existing skipped test documenting this future-date guard gap. Worker DAR has a stronger clock-skew rule; Core envelope scoring should probably receive the same future-date tolerance in a later guard extraction.
+Worker DAR keeps its separate half-life fallback for Store ranking continuity. The Core guard does not change Worker DAR, D1, or Store behavior.
 
 ## 6. Worker DAR Engine
 
@@ -753,9 +749,9 @@ Covered:
 - structured JSON envelope shape
 - text envelope shape
 
-Known gap:
+Covered:
 
-- future date tolerance in Core envelope scoring is documented by a skipped test.
+- future date tolerance in Core envelope scoring is covered by active tests.
 
 ### DAR
 
@@ -828,15 +824,11 @@ This is good. The math primitives are now real, but production wiring can be rev
 
 ### 17.1 Future Timestamp Handling
 
-Core envelope scoring still treats future timestamps as age `0` through `max(0, retrieved - published)`.
+Core envelope scoring now tolerates up to 5 minutes of clock skew and returns `freshness_score: null` for meaningfully future-dated content.
 
-Question:
+Status:
 
-Should Core envelope scoring adopt the same 5-minute clock skew tolerance and half-life fallback as Worker DAR?
-
-Recommendation:
-
-Yes, in a focused guard patch.
+Resolved for Core envelope scoring in Phase 3-D. Worker DAR remains intentionally unchanged and continues to use its Store-oriented half-life fallback for meaningfully future timestamps.
 
 ### 17.2 Lambda Table Duplication
 
@@ -943,7 +935,7 @@ Ask reviewers to answer:
 
 1. Is exponential decay the right base model for the current source classes?
 2. Are the lambda values plausible as default/reference half-lives?
-3. Should future-dated envelope content be handled more conservatively?
+3. Is the Core future-dated envelope policy conservative enough for public context metadata?
 4. Is the current `R_0` rule-based profile score acceptable as a first Store implementation?
 5. Should context-conditioned utility replace or augment the Worker `R_0` model later?
 6. Is `status = unknown` factor `0.5` too generous?
@@ -974,9 +966,9 @@ Recommended sequence:
    - Clarify Ha-Pri v1 comments as provenance stamp / audit reference.
    - Avoid proof-of-origin language unless HMAC or private signing is added.
 
-3. Fix Core future timestamp guard.
-   - Add tolerance.
-   - Align with methodology/spec.
+3. Fix Core future timestamp guard. Completed in Phase 3-D.
+   - Add 5-minute clock skew tolerance.
+   - Return no numeric Core freshness score for meaningfully future-dated content.
    - Activate skipped test.
 
 4. Decide crypto compatibility.

--- a/src/core/decay.ts
+++ b/src/core/decay.ts
@@ -26,6 +26,22 @@ export const LAMBDA: Record<string, number> = {
   default:           0.001,
 };
 
+export const FUTURE_CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000;
+
+export function isMeaningfullyFutureDate(
+  content_date: string | null,
+  retrieved_at: string
+): boolean {
+  if (!content_date) return false;
+
+  const published = new Date(content_date).getTime();
+  const retrieved = new Date(retrieved_at).getTime();
+
+  if (isNaN(published) || isNaN(retrieved)) return false;
+
+  return published - retrieved > FUTURE_CLOCK_SKEW_TOLERANCE_MS;
+}
+
 export function calculateFreshnessScore(
   content_date: string | null,
   retrieved_at: string,
@@ -37,6 +53,7 @@ export function calculateFreshnessScore(
   const retrieved = new Date(retrieved_at).getTime();
 
   if (isNaN(published) || isNaN(retrieved)) return null;
+  if (published - retrieved > FUTURE_CLOCK_SKEW_TOLERANCE_MS) return null;
 
   const hoursSinceRetrieved = Math.max(0, (retrieved - published) / (1000 * 60 * 60));
   const lambda = LAMBDA[adapter] ?? LAMBDA.default;

--- a/src/core/envelope.ts
+++ b/src/core/envelope.ts
@@ -1,5 +1,5 @@
 import type { FreshContext, AdapterResult, ExtractOptions, EnvelopeFormatOptions } from "./types.js";
-import { calculateFreshnessScore, scoreLabel } from "./decay.js";
+import { calculateFreshnessScore, isMeaningfullyFutureDate, scoreLabel } from "./decay.js";
 import { looksLikeFailedAdapterContent } from "./guards.js";
 
 export function stampFreshness(
@@ -10,7 +10,8 @@ export function stampFreshness(
   const retrieved_at = new Date().toISOString();
   const failedContent = looksLikeFailedAdapterContent(result.raw);
   const content_date = failedContent ? null : result.content_date;
-  const freshness_confidence = failedContent ? "low" : result.freshness_confidence;
+  const futureDated = !failedContent && isMeaningfullyFutureDate(content_date, retrieved_at);
+  const freshness_confidence = failedContent || futureDated ? "low" : result.freshness_confidence;
   const freshness_score = calculateFreshnessScore(
     content_date,
     retrieved_at,

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -27,6 +27,10 @@ function hoursAgo(hours: number): string {
   return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
 }
 
+function minutesFrom(iso: string, minutes: number): string {
+  return new Date(new Date(iso).getTime() + minutes * 60 * 1000).toISOString();
+}
+
 const BASE_HA_PRI_V2_INPUT: HaPriV2Input = {
   resultId: "sr_test_123",
   rawContent: "Show HN: FreshContext\nhttps://example.com/freshcontext\nPublished: 2026-05-24",
@@ -54,6 +58,16 @@ test("Core calculateFreshnessScore handles valid, missing, and invalid dates", (
   assert.ok(score !== null && score >= 0 && score <= 100);
   assert.equal(calculateFreshnessScore(null, retrievedAt, "hackernews"), null);
   assert.equal(calculateFreshnessScore("not-a-date", retrievedAt, "hackernews"), null);
+});
+
+test("Core calculateFreshnessScore tolerates clock skew but rejects future timestamps", () => {
+  const retrievedAt = "2026-05-24T12:00:00.000Z";
+  const withinClockSkew = minutesFrom(retrievedAt, 5);
+  const beyondClockSkew = minutesFrom(retrievedAt, 6);
+
+  assert.equal(calculateFreshnessScore(withinClockSkew, retrievedAt, "hackernews"), 100);
+  assert.equal(calculateFreshnessScore(beyondClockSkew, retrievedAt, "hackernews"), null);
+  assert.equal(calculateFreshnessScore(minutesFrom(retrievedAt, 24 * 60), retrievedAt, "hackernews"), null);
 });
 
 test("Core scoreLabel preserves score bands", () => {

--- a/tests/freshnessStamp.test.ts
+++ b/tests/freshnessStamp.test.ts
@@ -80,14 +80,19 @@ test("adapter-specific decay behavior is preserved", () => {
   assert.ok((github.freshness_score ?? 0) > (hn.freshness_score ?? 0));
 });
 
-test("future dates beyond tolerance are not treated as fresh", { skip: "Current MCP stamping clamps future dates to fresh; activate when Core guards are extracted." }, () => {
+test("future dates beyond tolerance are not treated as fresh", () => {
   const ctx = stamp({
     raw: "Future-dated result",
     content_date: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
     freshness_confidence: "high",
   });
+  const text = formatForLLM(ctx);
 
-  assert.notEqual(ctx.freshness_score, 100);
+  assert.equal(ctx.freshness_score, null);
+  assert.equal(ctx.freshness_confidence, "low");
+  assert.match(text, /Score:\s*unknown/i);
+  assert.doesNotMatch(text, /Confidence:\s*high/i);
+  assert.doesNotMatch(text, /Score:\s*100\/100/i);
 });
 
 test("text envelope includes FreshContext fields", () => {


### PR DESCRIPTION
Fixes Core envelope freshness scoring so meaningfully future-dated content is not rewarded as maximally fresh.

Changes:
- adds a Core future timestamp guard
- tolerates small clock skew
- returns no numeric freshness score for meaningfully future-dated content
- activates/adds future-date tests
- preserves Worker DAR behavior
- preserves missing/invalid date behavior
- preserves failure-honesty behavior
- updates the math spine review note to mark the Core gap resolved

Validation:
- npm run build
- npm test
- npm run smoke:stdio
- npm run example:ha-pri-v2
- Worker typecheck
- git diff --check
- npm audit --omit=dev
- npm pack --dry-run --json

No Worker runtime changes.
No D1/schema changes.
No feed/Ops changes.
No deploy.
No npm publish.
No Ha-Pri v2 wiring.