### PR TITLE
FreshContext Signal Contract v1 — Core additive contract

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -44,6 +44,24 @@ import {
 
 These types describe the stable envelope and adapter result contract.
 
+## Signal Contract v1
+
+Signal Contract v1 is the additive Core shape for a retrieved signal before it is ranked, wrapped, stored, or passed to an agent workflow.
+
+Public exports:
+
+- `SIGNAL_CONTRACT_VERSION`
+- `normalizeSignal(input, options?)`
+- `FreshContextSignalInput`
+- `FreshContextSignal`
+- `SignalDateConfidence`
+- `SignalContractVersion`
+- `SignalNormalizeOptions`
+
+`published_at` is the canonical signal timestamp. `content_date` is accepted as an adapter/envelope compatibility alias. Normalization clears invalid or meaningfully future-dated timestamps, marks failed/error-looking content as `status: "failed"`, clamps `semantic_score` into `0..1`, and records normalization reasons.
+
+See [Signal Contract v1](./SIGNAL_CONTRACT.md).
+
 ## Public Ranking Primitives
 
 The ranking primitives are public, but consumers should treat their score scales carefully:

--- a/docs/SIGNAL_CONTRACT.md
+++ b/docs/SIGNAL_CONTRACT.md
@@ -1,0 +1,89 @@
+# FreshContext Signal Contract v1
+
+FreshContext Signal Contract v1 defines the Core shape for a retrieved signal before it is ranked, wrapped, stored, or passed to an agent workflow.
+
+It is an additive Core API. It does not change MCP tool schemas, Worker runtime behavior, D1 schema, Store scoring, feeds, or deployment behavior.
+
+## Contract Version
+
+```ts
+type SignalContractVersion = "freshcontext.signal.v1";
+```
+
+Every normalized signal includes:
+
+```ts
+contract_version: "freshcontext.signal.v1"
+```
+
+## Input Shape
+
+`FreshContextSignalInput` accepts the common fields used by adapters, agents, ranking, and future Store wiring:
+
+```ts
+interface FreshContextSignalInput {
+  id?: string;
+  source: string;
+  source_type?: string;
+  title?: string;
+  content?: string;
+  published_at?: string | null;
+  content_date?: string | null;
+  retrieved_at?: string | null;
+  semantic_score?: number;
+  date_confidence?: "high" | "medium" | "low" | "unknown";
+  freshness_confidence?: "high" | "medium" | "low";
+  status?: "success" | "partial" | "stale" | "failed" | "unknown";
+  metadata?: Record<string, unknown>;
+}
+```
+
+`published_at` is the canonical signal timestamp. `content_date` is accepted as an adapter/envelope compatibility alias.
+
+## Normalized Output
+
+`normalizeSignal(input, options?)` returns a `FreshContextSignal`:
+
+```ts
+interface FreshContextSignal {
+  contract_version: "freshcontext.signal.v1";
+  id?: string;
+  source: string;
+  source_type: string;
+  title?: string;
+  content?: string;
+  published_at: string | null;
+  retrieved_at: string;
+  semantic_score: number;
+  date_confidence: "high" | "medium" | "low" | "unknown";
+  status: "success" | "partial" | "stale" | "failed" | "unknown";
+  metadata: Record<string, unknown>;
+  reasons: string[];
+}
+```
+
+## Normalization Rules
+
+- Missing or invalid `published_at` / `content_date` becomes `published_at: null`.
+- `content_date` maps to `published_at` when `published_at` is absent.
+- Meaningfully future-dated timestamps are cleared and receive `date_confidence: "unknown"`.
+- Small clock skew is tolerated by the same Core freshness policy used by envelope scoring.
+- Failed, empty, timeout, blocked, or error-looking content becomes `status: "failed"`.
+- Missing, invalid, negative, or oversized `semantic_score` is clamped into `0..1`.
+- `metadata` is shallow-copied so normalization does not mutate caller-owned objects.
+- `reasons` records meaningful normalization changes.
+
+## Relationship to Existing Core Types
+
+The signal contract does not replace existing Core types:
+
+- `AdapterResult` remains the adapter-to-envelope input shape.
+- `FreshContext` remains the envelope output shape.
+- `FreshSignal` and `RankedSignal` remain the ranking input/output shapes.
+- `ContextUtilityInput` remains the pure context-conditioned utility primitive.
+
+The contract gives these surfaces a shared signal vocabulary without requiring Store, Worker, or MCP schema changes.
+
+## Boundary
+
+Signal Contract v1 does not determine truth, certify data, or provide legal, medical, tax, or financial advice. It provides normalized context metadata for freshness, provenance, relevance, and workflow review.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,7 @@ export { stampFreshness, toStructuredJSON, formatForLLM } from "./envelope.js";
 export { explainSignal } from "./explain.js";
 export { rankSignals, rankSignal, clampScore } from "./rank.js";
 export { calculateContextUtility } from "./utility.js";
+export { SIGNAL_CONTRACT_VERSION, normalizeSignal } from "./signal.js";
 export {
   canonicalizeHaPriContent,
   sha256Hex,
@@ -16,6 +17,11 @@ export type {
   AdapterResult,
   EnvelopeFormatOptions,
   SignalConfidence,
+  SignalDateConfidence,
+  SignalContractVersion,
+  SignalNormalizeOptions,
+  FreshContextSignalInput,
+  FreshContextSignal,
   FreshSignal,
   RankedSignal,
   RankOptions,

--- a/src/core/rank.ts
+++ b/src/core/rank.ts
@@ -42,8 +42,13 @@ function resolveSourceType(signal: FreshSignal, options: RankOptions): string {
   return signal.source_type ?? options.defaultSourceType ?? signal.source ?? "default";
 }
 
+function isFailedSignal(signal: FreshSignal): boolean {
+  return signal.status === "failed"
+    || (signal.content !== undefined && looksLikeFailedAdapterContent(signal.content));
+}
+
 function confidenceFor(signal: FreshSignal, semanticScore: number, freshnessScore: number | null): SignalConfidence {
-  if (signal.content !== undefined && looksLikeFailedAdapterContent(signal.content)) {
+  if (isFailedSignal(signal)) {
     return "low";
   }
   if (freshnessScore !== null && semanticScore >= 0.7) {
@@ -58,11 +63,13 @@ function confidenceFor(signal: FreshSignal, semanticScore: number, freshnessScor
 export function rankSignal(signal: FreshSignal, options: RankOptions = {}): RankedSignal {
   const weights = resolveWeights(options);
   const semantic_score = clampScore(signal.semantic_score);
-  const freshness_score = calculateFreshnessScore(
-    signal.published_at ?? null,
-    resolveRetrievedAt(signal, options),
-    resolveSourceType(signal, options)
-  );
+  const freshness_score = isFailedSignal(signal) || signal.date_confidence === "unknown"
+    ? null
+    : calculateFreshnessScore(
+      signal.published_at ?? signal.content_date ?? null,
+      resolveRetrievedAt(signal, options),
+      resolveSourceType(signal, options)
+    );
   const freshnessComponent = freshness_score === null ? 0 : clampScore(freshness_score / 100);
   const final_score = clampScore(
     semantic_score * weights.semantic + freshnessComponent * weights.freshness

--- a/src/core/signal.ts
+++ b/src/core/signal.ts
@@ -1,0 +1,129 @@
+import { isMeaningfullyFutureDate } from "./decay.js";
+import { looksLikeFailedAdapterContent } from "./guards.js";
+import type {
+  ContextUtilityStatus,
+  FreshContextSignal,
+  FreshContextSignalInput,
+  SignalDateConfidence,
+  SignalNormalizeOptions,
+} from "./types.js";
+
+export const SIGNAL_CONTRACT_VERSION = "freshcontext.signal.v1" as const;
+
+const DATE_CONFIDENCE_VALUES = new Set(["high", "medium", "low", "unknown"]);
+const STATUS_VALUES = new Set(["success", "partial", "stale", "failed", "unknown"]);
+
+function isSignalDateConfidence(value: unknown): value is SignalDateConfidence {
+  return typeof value === "string" && DATE_CONFIDENCE_VALUES.has(value);
+}
+
+function isContextUtilityStatus(value: unknown): value is ContextUtilityStatus {
+  return typeof value === "string" && STATUS_VALUES.has(value);
+}
+
+function normalizeDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+
+  const timestamp = new Date(value).getTime();
+  if (isNaN(timestamp)) return null;
+
+  return new Date(timestamp).toISOString();
+}
+
+function resolveRetrievedAt(
+  input: FreshContextSignalInput,
+  options: SignalNormalizeOptions,
+  reasons: string[]
+): string {
+  const retrievedAt = normalizeDate(input.retrieved_at);
+  if (retrievedAt) return retrievedAt;
+
+  if (input.retrieved_at) {
+    reasons.push("retrieved_at was invalid; used normalization time");
+  }
+
+  const optionNow = options.now instanceof Date
+    ? (isNaN(options.now.getTime()) ? null : options.now.toISOString())
+    : normalizeDate(options.now);
+
+  return optionNow ?? new Date().toISOString();
+}
+
+function normalizeSemanticScore(value: unknown, reasons: string[]): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    reasons.push("semantic_score was missing or invalid; clamped to 0");
+    return 0;
+  }
+  if (value < 0) {
+    reasons.push("semantic_score was below 0; clamped to 0");
+    return 0;
+  }
+  if (value > 1) {
+    reasons.push("semantic_score exceeded 1; clamped to 1");
+    return 1;
+  }
+  return value;
+}
+
+function resolveDateConfidence(
+  input: FreshContextSignalInput,
+  hasTrustedDate: boolean
+): SignalDateConfidence {
+  if (!hasTrustedDate) return "unknown";
+  if (isSignalDateConfidence(input.date_confidence)) return input.date_confidence;
+  if (input.freshness_confidence) return input.freshness_confidence;
+  return "medium";
+}
+
+function resolveStatus(input: FreshContextSignalInput, failedContent: boolean): ContextUtilityStatus {
+  if (failedContent) return "failed";
+  if (isContextUtilityStatus(input.status)) return input.status;
+  return "success";
+}
+
+export function normalizeSignal(
+  input: FreshContextSignalInput,
+  options: SignalNormalizeOptions = {}
+): FreshContextSignal {
+  const reasons: string[] = [];
+  const retrieved_at = resolveRetrievedAt(input, options, reasons);
+  const rawPublishedAt = input.published_at ?? input.content_date ?? null;
+  let published_at = normalizeDate(rawPublishedAt);
+
+  if (!input.published_at && input.content_date) {
+    reasons.push("content_date alias was normalized to published_at");
+  }
+  if (rawPublishedAt && !published_at) {
+    reasons.push("published_at/content_date was invalid; cleared");
+  }
+  if (published_at && isMeaningfullyFutureDate(published_at, retrieved_at)) {
+    published_at = null;
+    reasons.push("published_at/content_date was meaningfully future-dated; cleared");
+  }
+
+  const failedContent = input.content !== undefined && looksLikeFailedAdapterContent(input.content);
+  if (failedContent) {
+    reasons.push("content looked like failed adapter output; status set to failed");
+  }
+
+  const source_type = input.source_type ?? options.defaultSourceType ?? "default";
+  if (!input.source_type && !options.defaultSourceType) {
+    reasons.push("source_type was missing; defaulted to default");
+  }
+
+  return {
+    contract_version: SIGNAL_CONTRACT_VERSION,
+    id: input.id,
+    source: input.source,
+    source_type,
+    title: input.title,
+    content: input.content,
+    published_at,
+    retrieved_at,
+    semantic_score: normalizeSemanticScore(input.semantic_score, reasons),
+    date_confidence: resolveDateConfidence(input, published_at !== null),
+    status: resolveStatus(input, failedContent),
+    metadata: input.metadata ? { ...input.metadata } : {},
+    reasons,
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -30,6 +30,52 @@ export interface EnvelopeFormatOptions {
 }
 
 export type SignalConfidence = "high" | "medium" | "low";
+export type SignalDateConfidence = SignalConfidence | "unknown";
+export type SignalContractVersion = "freshcontext.signal.v1";
+
+export type ContextUtilityStatus =
+  | "success"
+  | "partial"
+  | "stale"
+  | "failed"
+  | "unknown";
+
+export interface SignalNormalizeOptions {
+  defaultSourceType?: string;
+  now?: Date | string;
+}
+
+export interface FreshContextSignalInput {
+  id?: string;
+  source: string;
+  source_type?: string;
+  title?: string;
+  content?: string;
+  published_at?: string | null;
+  content_date?: string | null;
+  retrieved_at?: string | null;
+  semantic_score?: number;
+  date_confidence?: SignalDateConfidence;
+  freshness_confidence?: SignalConfidence;
+  status?: ContextUtilityStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface FreshContextSignal {
+  contract_version: SignalContractVersion;
+  id?: string;
+  source: string;
+  source_type: string;
+  title?: string;
+  content?: string;
+  published_at: string | null;
+  retrieved_at: string;
+  semantic_score: number;
+  date_confidence: SignalDateConfidence;
+  status: ContextUtilityStatus;
+  metadata: Record<string, unknown>;
+  reasons: string[];
+}
 
 export interface FreshSignal {
   id?: string;
@@ -38,8 +84,12 @@ export interface FreshSignal {
   title?: string;
   content?: string;
   published_at?: string | null;
+  content_date?: string | null;
   retrieved_at?: string | null;
   semantic_score: number;
+  date_confidence?: SignalDateConfidence;
+  freshness_confidence?: SignalConfidence;
+  status?: ContextUtilityStatus;
   metadata?: Record<string, unknown>;
 }
 
@@ -56,13 +106,6 @@ export interface RankOptions {
   defaultSourceType?: string;
   now?: Date | string;
 }
-
-export type ContextUtilityStatus =
-  | "success"
-  | "partial"
-  | "stale"
-  | "failed"
-  | "unknown";
 
 export interface ContextUtilityInput {
   contextualRelevance: number;

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -13,11 +13,15 @@ import {
   sha256Hex,
   calculateHaPriV2,
   verifyHaPriV2,
+  SIGNAL_CONTRACT_VERSION,
+  normalizeSignal,
 } from "../src/core/index.js";
 import type {
   AdapterResult,
   ContextUtilityResult,
   ExtractOptions,
+  FreshContextSignal,
+  FreshContextSignalInput,
   FreshContext,
   HaPriV2Input,
   HaPriV2Result,
@@ -76,6 +80,127 @@ test("Core scoreLabel preserves score bands", () => {
   assert.equal(scoreLabel(75), "reliable");
   assert.equal(scoreLabel(55), "verify before acting");
   assert.equal(scoreLabel(20), "use with caution");
+});
+
+test("Core normalizeSignal emits the Signal Contract v1 shape for normal signals", () => {
+  const signal: FreshContextSignal = normalizeSignal({
+    id: "sig_normal",
+    source: "https://example.com/normal",
+    source_type: "hackernews",
+    title: "Normal signal",
+    content: "FreshContext signal contract content",
+    published_at: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+    semantic_score: 0.82,
+    date_confidence: "high",
+    status: "success",
+    metadata: { topic: "core" },
+  });
+
+  assert.equal(signal.contract_version, SIGNAL_CONTRACT_VERSION);
+  assert.equal(signal.source_type, "hackernews");
+  assert.equal(signal.published_at, "2026-05-24T10:00:00.000Z");
+  assert.equal(signal.retrieved_at, "2026-05-24T11:00:00.000Z");
+  assert.equal(signal.semantic_score, 0.82);
+  assert.equal(signal.date_confidence, "high");
+  assert.equal(signal.status, "success");
+  assert.deepEqual(signal.metadata, { topic: "core" });
+  assert.deepEqual(signal.reasons, []);
+});
+
+test("Core normalizeSignal maps content_date alias to published_at", () => {
+  const signal = normalizeSignal({
+    source: "https://example.com/content-date",
+    source_type: "github",
+    content_date: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+    semantic_score: 0.7,
+    freshness_confidence: "medium",
+  });
+
+  assert.equal(signal.published_at, "2026-05-24T10:00:00.000Z");
+  assert.equal(signal.date_confidence, "medium");
+  assert.ok(signal.reasons.some((reason) => reason.includes("content_date alias")));
+});
+
+test("Core normalizeSignal clears missing, invalid, and meaningfully future dates", () => {
+  const retrievedAt = "2026-05-24T12:00:00.000Z";
+  const missing = normalizeSignal({
+    source: "https://example.com/missing-date",
+    source_type: "blog",
+    retrieved_at: retrievedAt,
+    semantic_score: 0.7,
+  });
+  const invalid = normalizeSignal({
+    source: "https://example.com/invalid-date",
+    source_type: "blog",
+    published_at: "not-a-date",
+    retrieved_at: retrievedAt,
+    semantic_score: 0.7,
+  });
+  const future = normalizeSignal({
+    source: "https://example.com/future-date",
+    source_type: "blog",
+    published_at: minutesFrom(retrievedAt, 6),
+    retrieved_at: retrievedAt,
+    semantic_score: 0.7,
+    date_confidence: "high",
+  });
+
+  assert.equal(missing.published_at, null);
+  assert.equal(missing.date_confidence, "unknown");
+  assert.equal(invalid.published_at, null);
+  assert.equal(invalid.date_confidence, "unknown");
+  assert.ok(invalid.reasons.some((reason) => reason.includes("invalid")));
+  assert.equal(future.published_at, null);
+  assert.equal(future.date_confidence, "unknown");
+  assert.ok(future.reasons.some((reason) => reason.includes("future-dated")));
+});
+
+test("Core normalizeSignal marks failed content and clamps semantic scores", () => {
+  const invalidScore = normalizeSignal({
+    source: "https://example.com/invalid-score",
+    source_type: "github",
+    published_at: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+  });
+  const oversizedScore = normalizeSignal({
+    source: "https://example.com/oversized-score",
+    source_type: "github",
+    published_at: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+    semantic_score: 2,
+  });
+  const failed = normalizeSignal({
+    source: "https://example.com/failed",
+    source_type: "github",
+    content: "[Error] upstream timeout",
+    published_at: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+    semantic_score: 0.9,
+  });
+
+  assert.equal(invalidScore.semantic_score, 0);
+  assert.ok(invalidScore.reasons.some((reason) => reason.includes("semantic_score")));
+  assert.equal(oversizedScore.semantic_score, 1);
+  assert.equal(failed.status, "failed");
+  assert.ok(failed.reasons.some((reason) => reason.includes("failed adapter output")));
+});
+
+test("Core normalizeSignal does not mutate caller-owned input", () => {
+  const input: FreshContextSignalInput = {
+    source: "https://example.com/no-mutation",
+    source_type: "hackernews",
+    published_at: "2026-05-24T10:00:00.000Z",
+    retrieved_at: "2026-05-24T11:00:00.000Z",
+    semantic_score: 0.8,
+    metadata: { nested: { value: true } },
+  };
+  const snapshot = JSON.stringify(input);
+
+  normalizeSignal(input);
+
+  assert.equal(JSON.stringify(input), snapshot);
 });
 
 test("Core failure guard detects empty, security, timeout, and error-like output", () => {

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -7,9 +7,11 @@ import {
   explainSignal,
   formatForLLM,
   looksLikeFailedAdapterContent,
+  normalizeSignal,
   rankSignal,
   rankSignals,
   scoreLabel,
+  SIGNAL_CONTRACT_VERSION,
   stampFreshness,
   toStructuredJSON,
 } from "../src/core/index.js";
@@ -19,6 +21,8 @@ import type {
   ContextUtilityResult,
   EnvelopeFormatOptions,
   ExtractOptions,
+  FreshContextSignal,
+  FreshContextSignalInput,
   FreshContext,
   FreshSignal,
   HaPriV2Input,
@@ -56,6 +60,25 @@ test("public Core API imports compile and callable functions remain available", 
   assert.equal(typeof scoreLabel(freshnessScore), "string");
   assert.equal(looksLikeFailedAdapterContent(result.raw), false);
   assert.equal(looksLikeFailedAdapterContent("[Error] upstream timeout"), true);
+});
+
+test("public signal contract imports compile and normalize signals", () => {
+  const input: FreshContextSignalInput = {
+    source: "https://example.com/signal-contract",
+    source_type: "hackernews",
+    content_date: "2026-05-24T12:00:00.000Z",
+    retrieved_at: "2026-05-24T13:00:00.000Z",
+    semantic_score: 0.9,
+    freshness_confidence: "high",
+  };
+
+  const signal: FreshContextSignal = normalizeSignal(input);
+
+  assert.equal(SIGNAL_CONTRACT_VERSION, "freshcontext.signal.v1");
+  assert.equal(signal.contract_version, SIGNAL_CONTRACT_VERSION);
+  assert.equal(signal.published_at, input.content_date);
+  assert.equal(signal.date_confidence, "high");
+  assert.equal(signal.status, "success");
 });
 
 test("public ranking and utility imports compile and remain callable", () => {

--- a/tests/rank.test.ts
+++ b/tests/rank.test.ts
@@ -55,6 +55,34 @@ test("missing date still ranks with lower confidence and missing-date reason", (
   assert.ok(ranked.final_score < 0.8);
 });
 
+test("failed Core signals do not receive numeric freshness or high confidence", () => {
+  const explicitFailed = rankSignal({
+    id: "explicit-failed",
+    source: "https://example.com/explicit-failed",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    retrieved_at: now,
+    semantic_score: 0.95,
+    content: "Fresh-looking content from a failed upstream call",
+    status: "failed",
+  }, options);
+  const failedContent = rankSignal({
+    id: "failed-content",
+    source: "https://example.com/failed-content",
+    source_type: "hackernews",
+    published_at: "2026-05-13T09:00:00.000Z",
+    retrieved_at: now,
+    semantic_score: 0.95,
+    content: "[Error] upstream timeout",
+  }, options);
+
+  assert.equal(explicitFailed.freshness_score, null);
+  assert.equal(explicitFailed.confidence, "low");
+  assert.ok(explicitFailed.final_score < 0.95);
+  assert.equal(failedContent.freshness_score, null);
+  assert.equal(failedContent.confidence, "low");
+});
+
 test("final_score and clampScore stay in the normalized 0..1 range", () => {
   assert.equal(clampScore(-1), 0);
   assert.equal(clampScore(2), 1);


### PR DESCRIPTION
Adds FreshContext Signal Contract v1 as an additive Core API.

Changes:
- adds `FreshContextSignalInput`, `FreshContextSignal`, `SignalDateConfidence`, `SignalContractVersion`, and `SignalNormalizeOptions`
- adds `SIGNAL_CONTRACT_VERSION` and `normalizeSignal(input, options?)`
- uses `published_at` as the canonical signal timestamp and accepts `content_date` as an alias
- normalizes missing, invalid, and meaningfully future-dated timestamps conservatively
- marks failed/error-looking content as `status: failed`
- clamps `semantic_score` into `0..1`
- keeps existing `AdapterResult`, `FreshContext`, `FreshSignal`, and `RankedSignal` paths compatible
- updates ranking narrowly so failed Core signals are not rewarded with numeric freshness
- documents Signal Contract v1 and links it from Core API docs

Validation:
- npm run build
- npm test
- npm run smoke:stdio
- npm run example:ha-pri-v2
- Worker typecheck
- git diff --check
- npm audit --omit=dev
- npm pack --dry-run --json

Note: the local workspace has pre-existing uncommitted trust-scan files and package.json edits outside this PR. They were not staged or committed here.

No Worker runtime changes.
No D1/schema changes.
No feed/Ops changes.
No MCP tool schema changes.
No package version change.
No deploy.
No npm publish.