### PR TITLE
Pass 8-B — Core signal evaluation pipeline

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -1,6 +1,6 @@
 # FreshContext Core API
 
-FreshContext Core is the reusable engine layer in the current integrated MCP/Core package. It owns envelope creation, freshness scoring, failure honesty, rank/explain primitives, and the experimental context-utility primitive.
+FreshContext Core is the reusable engine layer in the current integrated MCP/Core package. It owns signal normalization, envelope creation, freshness scoring, failure honesty, rank/explain primitives, the context-utility primitive, and pure provenance helpers.
 
 MCP, Worker HTTP, future REST, and future CLI/SDK surfaces should use Core as the contract center instead of redefining freshness or envelope behavior per host.
 
@@ -33,6 +33,25 @@ import {
 ### Guards
 
 - `looksLikeFailedAdapterContent(raw)` detects empty, security, timeout, and error-like adapter output so failed content is not stamped as fresh high-confidence context.
+
+## Core Evaluation Pipeline
+
+The Core evaluation pipeline is the pure orchestration layer over the existing primitives.
+
+Public exports:
+
+- `evaluateSignal(input, options?)`
+- `evaluateSignals(inputs, options?)`
+- `CoreSignalEvaluationOptions`
+- `CoreSignalEvaluationResult`
+- `CoreSignalEnvelopeResult`
+- `CoreSignalProvenanceOptions`
+
+`evaluateSignal` normalizes a signal, applies timestamp/failure guards, computes `freshness_score`, computes context-conditioned utility, ranks/explains the signal, optionally creates a FreshContext envelope, and optionally prepares Ha-Pri v2 provenance material.
+
+It does not fetch, cache, write D1, inspect Worker bindings, know MCP tool schemas, deploy, or publish. Hosts decide whether to store, cache, transmit, or expose the returned result.
+
+`evaluateSignals` evaluates each input and returns evaluations sorted by existing `rankSignal` final score, preserving input order when scores tie. Context utility is returned as a sidecar and does not replace `final_score`.
 
 ### Stable Types
 
@@ -92,7 +111,21 @@ Experimental exports:
 - `ContextUtilityInput`
 - `ContextUtilityResult`
 
-These are part of Math Spine Phase 1. Treat them as experimental until a later math integration pass decides how they should affect production ranking or external APIs.
+These are pure Core math. They are now connected inside `evaluateSignal` as sidecar utility output, but they are not production-wired into MCP ranking, Worker feeds, Store scoring, or runtime behavior.
+
+## Provenance Helpers
+
+Ha-Pri v2 is available as pure Core helper functionality:
+
+- `canonicalizeHaPriContent`
+- `sha256Hex`
+- `calculateHaPriV2`
+- `verifyHaPriV2`
+- `HaPriV2Input`
+- `HaPriV2Result`
+- `HaPriV2VerificationResult`
+
+`evaluateSignal` can optionally prepare Ha-Pri v2 material when `includeProvenance` is set and required input material is present. Core does not persist provenance, add D1 columns, verify rows on read, reject rows, or replace Worker Ha-Pri v1 behavior.
 
 ## Internal, Policy, and Compatibility Exports
 
@@ -116,7 +149,6 @@ Core does not own:
 - Cache metadata injection
 - D1, feed, or cron behavior
 - Store/feed scoring and provenance persistence
-- Ha-Pri v2
 - Hosted dashboard, API, deployment, or runtime concerns
 
 Hosts may wrap Core outputs with their own transport, cache, session, rate-limit, or persistence metadata, but they should not fork the Core envelope and freshness contract without an explicit compatibility reason.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,6 +5,7 @@ export { explainSignal } from "./explain.js";
 export { rankSignals, rankSignal, clampScore } from "./rank.js";
 export { calculateContextUtility } from "./utility.js";
 export { SIGNAL_CONTRACT_VERSION, normalizeSignal } from "./signal.js";
+export { evaluateSignal, evaluateSignals } from "./pipeline.js";
 export {
   canonicalizeHaPriContent,
   sha256Hex,
@@ -33,4 +34,8 @@ export type {
   HaPriV2Result,
   HaPriVerificationStatus,
   HaPriV2VerificationResult,
+  CoreSignalProvenanceOptions,
+  CoreSignalEnvelopeResult,
+  CoreSignalEvaluationOptions,
+  CoreSignalEvaluationResult,
 } from "./types.js";

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,0 +1,131 @@
+import { LAMBDA, calculateFreshnessScore } from "./decay.js";
+import { formatForLLM, toStructuredJSON } from "./envelope.js";
+import { calculateHaPriV2 } from "./provenance.js";
+import { rankSignal } from "./rank.js";
+import { normalizeSignal } from "./signal.js";
+import { calculateContextUtility } from "./utility.js";
+import type {
+  CoreSignalEvaluationOptions,
+  CoreSignalEvaluationResult,
+  CoreSignalEnvelopeResult,
+  FreshContext,
+  FreshContextSignal,
+  FreshContextSignalInput,
+  HaPriV2Result,
+  SignalConfidence,
+} from "./types.js";
+
+function ageHours(signal: FreshContextSignal): number {
+  if (!signal.published_at) return 0;
+  const published = new Date(signal.published_at).getTime();
+  const retrieved = new Date(signal.retrieved_at).getTime();
+  if (isNaN(published) || isNaN(retrieved)) return 0;
+  return Math.max(0, (retrieved - published) / (1000 * 60 * 60));
+}
+
+function envelopeConfidence(signal: FreshContextSignal): SignalConfidence {
+  if (signal.status === "failed" || signal.date_confidence === "unknown") return "low";
+  return signal.date_confidence;
+}
+
+function createEnvelope(
+  signal: FreshContextSignal,
+  freshnessScore: number | null,
+  options: CoreSignalEvaluationOptions
+): CoreSignalEnvelopeResult | undefined {
+  if (!options.includeEnvelope || signal.content === undefined) return undefined;
+
+  const ctx: FreshContext = {
+    content: signal.content.slice(0, options.envelopeMaxLength ?? 8000),
+    source_url: signal.source,
+    content_date: signal.published_at,
+    retrieved_at: signal.retrieved_at,
+    freshness_confidence: envelopeConfidence(signal),
+    freshness_score: freshnessScore,
+    adapter: signal.source_type,
+  };
+
+  return {
+    context: ctx,
+    text: formatForLLM(ctx, options.envelopeFormat),
+    structured: toStructuredJSON(ctx),
+  };
+}
+
+function createProvenance(
+  signal: FreshContextSignal,
+  options: CoreSignalEvaluationOptions,
+  reasons: string[]
+): HaPriV2Result | undefined {
+  if (!options.includeProvenance) return undefined;
+
+  const resultId = options.provenance?.resultId ?? signal.id;
+  const engineVersion = options.provenance?.engineVersion;
+  if (!signal.content) {
+    reasons.push("provenance was requested but content was missing");
+    return undefined;
+  }
+  if (!resultId) {
+    reasons.push("provenance was requested but resultId was missing");
+    return undefined;
+  }
+  if (!engineVersion) {
+    reasons.push("provenance was requested but engineVersion was missing");
+    return undefined;
+  }
+
+  return calculateHaPriV2({
+    resultId,
+    rawContent: signal.content,
+    semanticFingerprint: options.provenance?.semanticFingerprint ?? null,
+    adapter: signal.source_type,
+    publishedAt: signal.published_at,
+    retrievedAt: signal.retrieved_at,
+    engineVersion,
+  });
+}
+
+export function evaluateSignal(
+  input: FreshContextSignalInput,
+  options: CoreSignalEvaluationOptions = {}
+): CoreSignalEvaluationResult {
+  const signal = normalizeSignal(input, options);
+  const freshness_score = signal.status === "failed" || signal.date_confidence === "unknown"
+    ? null
+    : calculateFreshnessScore(signal.published_at, signal.retrieved_at, signal.source_type);
+  const utility = calculateContextUtility({
+    contextualRelevance: signal.semantic_score * 100,
+    lambda: LAMBDA[signal.source_type] ?? LAMBDA.default,
+    ageHours: ageHours(signal),
+    dateConfidence: signal.date_confidence,
+    status: signal.status,
+  });
+  const ranked = rankSignal(signal, options);
+  const reasons = [...signal.reasons, ...utility.reasons];
+  const envelope = createEnvelope(signal, freshness_score, options);
+  const provenance = createProvenance(signal, options, reasons);
+
+  return {
+    signal,
+    freshness_score,
+    utility,
+    ranked,
+    explanation: ranked.reason,
+    envelope,
+    provenance,
+    reasons,
+  };
+}
+
+export function evaluateSignals(
+  inputs: FreshContextSignalInput[],
+  options: CoreSignalEvaluationOptions = {}
+): CoreSignalEvaluationResult[] {
+  return inputs
+    .map((input, index) => ({ evaluation: evaluateSignal(input, options), index }))
+    .sort((a, b) => {
+      const scoreDiff = b.evaluation.ranked.final_score - a.evaluation.ranked.final_score;
+      return scoreDiff !== 0 ? scoreDiff : a.index - b.index;
+    })
+    .map(({ evaluation }) => evaluation);
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -161,3 +161,34 @@ export interface HaPriV2VerificationResult {
   actual: string | null;
   reasons: string[];
 }
+
+export interface CoreSignalProvenanceOptions {
+  resultId?: string;
+  semanticFingerprint?: string | null;
+  engineVersion?: string;
+}
+
+export interface CoreSignalEnvelopeResult {
+  context: FreshContext;
+  text: string;
+  structured: object;
+}
+
+export interface CoreSignalEvaluationOptions extends SignalNormalizeOptions, RankOptions {
+  includeEnvelope?: boolean;
+  envelopeMaxLength?: number;
+  envelopeFormat?: EnvelopeFormatOptions;
+  includeProvenance?: boolean;
+  provenance?: CoreSignalProvenanceOptions;
+}
+
+export interface CoreSignalEvaluationResult {
+  signal: FreshContextSignal;
+  freshness_score: number | null;
+  utility: ContextUtilityResult;
+  ranked: RankedSignal;
+  explanation: string;
+  envelope?: CoreSignalEnvelopeResult;
+  provenance?: HaPriV2Result;
+  reasons: string[];
+}

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -5,6 +5,8 @@ import {
   calculateHaPriV2,
   calculateFreshnessScore,
   explainSignal,
+  evaluateSignal,
+  evaluateSignals,
   formatForLLM,
   looksLikeFailedAdapterContent,
   normalizeSignal,
@@ -19,6 +21,8 @@ import type {
   AdapterResult,
   ContextUtilityInput,
   ContextUtilityResult,
+  CoreSignalEvaluationOptions,
+  CoreSignalEvaluationResult,
   EnvelopeFormatOptions,
   ExtractOptions,
   FreshContextSignal,
@@ -125,5 +129,37 @@ test("public ranking and utility imports compile and remain callable", () => {
   const haPri: HaPriV2Result = calculateHaPriV2(haPriInput);
 
   assert.match(haPri.haPriSigV2, /^[a-f0-9]{64}$/);
+});
+
+test("public Core evaluation pipeline imports compile and remain callable", () => {
+  const options: CoreSignalEvaluationOptions = {
+    now: "2026-05-24T13:00:00.000Z",
+    includeEnvelope: true,
+  };
+  const evaluation: CoreSignalEvaluationResult = evaluateSignal({
+    source: "https://example.com/evaluate",
+    source_type: "hackernews",
+    content: "Public Core evaluation contract content",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: "2026-05-24T13:00:00.000Z",
+    semantic_score: 0.8,
+    date_confidence: "high",
+  }, options);
+  const evaluations: CoreSignalEvaluationResult[] = evaluateSignals([
+    {
+      source: "https://example.com/evaluate",
+      source_type: "hackernews",
+      content: "Public Core evaluation contract content",
+      published_at: "2026-05-24T12:00:00.000Z",
+      retrieved_at: "2026-05-24T13:00:00.000Z",
+      semantic_score: 0.8,
+      date_confidence: "high",
+    },
+  ], options);
+
+  assert.equal(typeof evaluation.explanation, "string");
+  assert.equal(typeof evaluation.utility.score, "number");
+  assert.ok(evaluation.envelope);
+  assert.equal(evaluations.length, 1);
 });
 

--- a/tests/corePipeline.test.ts
+++ b/tests/corePipeline.test.ts
@@ -1,0 +1,199 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateSignal,
+  evaluateSignals,
+} from "../src/core/index.js";
+import type {
+  CoreSignalEvaluationOptions,
+  CoreSignalEvaluationResult,
+  FreshContextSignalInput,
+} from "../src/core/index.js";
+
+const NOW = "2026-05-24T13:00:00.000Z";
+
+function baseInput(overrides: Partial<FreshContextSignalInput> = {}): FreshContextSignalInput {
+  return {
+    id: "sig_test",
+    source: "https://example.com/signal",
+    source_type: "hackernews",
+    title: "FreshContext signal",
+    content: "FreshContext pipeline content",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.9,
+    date_confidence: "high",
+    status: "success",
+    metadata: { topic: "core" },
+    ...overrides,
+  };
+}
+
+test("evaluateSignal returns normalized signal, freshness, utility, rank, and explanation", () => {
+  const result = evaluateSignal(baseInput(), { now: NOW });
+
+  assert.equal(result.signal.contract_version, "freshcontext.signal.v1");
+  assert.equal(result.signal.published_at, "2026-05-24T12:00:00.000Z");
+  assert.equal(result.signal.retrieved_at, NOW);
+  assert.equal(typeof result.freshness_score, "number");
+  assert.ok(result.utility.score > 0);
+  assert.equal(result.ranked.freshness_score, result.freshness_score);
+  assert.equal(result.explanation, result.ranked.reason);
+  assert.deepEqual(result.signal.metadata, { topic: "core" });
+});
+
+test("evaluateSignal gives missing timestamps unknown date confidence and zero utility", () => {
+  const result = evaluateSignal(baseInput({
+    published_at: null,
+    date_confidence: "high",
+  }), { now: NOW });
+
+  assert.equal(result.signal.published_at, null);
+  assert.equal(result.signal.date_confidence, "unknown");
+  assert.equal(result.freshness_score, null);
+  assert.equal(result.utility.score, 0);
+  assert.equal(result.ranked.freshness_score, null);
+  assert.match(result.reasons.join(" "), /unknown/);
+});
+
+test("evaluateSignal prevents failed content from ranking as high-confidence fresh context", () => {
+  const result = evaluateSignal(baseInput({
+    content: "[Error] upstream timeout",
+    semantic_score: 0.95,
+  }), { now: NOW });
+
+  assert.equal(result.signal.status, "failed");
+  assert.equal(result.freshness_score, null);
+  assert.equal(result.utility.score, 0);
+  assert.equal(result.ranked.confidence, "low");
+  assert.equal(result.ranked.freshness_score, null);
+});
+
+test("evaluateSignal clears future timestamps before scoring", () => {
+  const result = evaluateSignal(baseInput({
+    published_at: "2026-05-24T13:06:00.000Z",
+    date_confidence: "high",
+  }), { now: NOW });
+
+  assert.equal(result.signal.published_at, null);
+  assert.equal(result.signal.date_confidence, "unknown");
+  assert.equal(result.freshness_score, null);
+  assert.equal(result.utility.score, 0);
+  assert.ok(result.reasons.some((reason) => reason.includes("future-dated")));
+});
+
+test("evaluateSignal can emit a FreshContext-compatible envelope without host code", () => {
+  const result = evaluateSignal(baseInput(), {
+    now: NOW,
+    includeEnvelope: true,
+    envelopeMaxLength: 12,
+    envelopeFormat: { unknownDateText: "Published: unknown" },
+  });
+
+  assert.ok(result.envelope);
+  assert.equal(result.envelope.context.content, "FreshContext");
+  assert.equal(result.envelope.context.source_url, "https://example.com/signal");
+  assert.equal(result.envelope.context.content_date, "2026-05-24T12:00:00.000Z");
+  assert.match(result.envelope.text, /\[FRESHCONTEXT\]/);
+  assert.match(result.envelope.text, /\[FRESHCONTEXT_JSON\]/);
+  assert.deepEqual(result.envelope.structured, {
+    freshcontext: {
+      source_url: result.envelope.context.source_url,
+      content_date: result.envelope.context.content_date,
+      retrieved_at: result.envelope.context.retrieved_at,
+      freshness_confidence: result.envelope.context.freshness_confidence,
+      freshness_score: result.envelope.context.freshness_score,
+      adapter: result.envelope.context.adapter,
+    },
+    content: result.envelope.context.content,
+  });
+});
+
+test("evaluateSignal emits optional Ha-Pri v2 provenance when required material is present", () => {
+  const result = evaluateSignal(baseInput(), {
+    now: NOW,
+    includeProvenance: true,
+    provenance: {
+      resultId: "sr_pipeline",
+      semanticFingerprint: "pipeline-fingerprint",
+      engineVersion: "freshcontext-0.3.17",
+    },
+  });
+
+  assert.ok(result.provenance);
+  assert.equal(result.provenance.resultId, "sr_pipeline");
+  assert.equal(result.provenance.adapter, "hackernews");
+  assert.equal(result.provenance.publishedAt, "2026-05-24T12:00:00.000Z");
+  assert.equal(result.provenance.retrievedAt, NOW);
+  assert.match(result.provenance.haPriSigV2, /^[a-f0-9]{64}$/);
+});
+
+test("evaluateSignal omits provenance and records reasons when required material is missing", () => {
+  const result = evaluateSignal(baseInput({ id: undefined }), {
+    now: NOW,
+    includeProvenance: true,
+    provenance: {
+      engineVersion: "freshcontext-0.3.17",
+    },
+  });
+
+  assert.equal(result.provenance, undefined);
+  assert.ok(result.reasons.some((reason) => reason.includes("resultId")));
+});
+
+test("evaluateSignals sorts by ranked score and preserves stable tie ordering", () => {
+  const first = baseInput({
+    id: "first",
+    source: "https://example.com/first",
+    semantic_score: 0.7,
+  });
+  const second = baseInput({
+    id: "second",
+    source: "https://example.com/second",
+    semantic_score: 0.95,
+  });
+  const tieA = baseInput({
+    id: "tie-a",
+    source: "https://example.com/tie-a",
+    semantic_score: 0.8,
+  });
+  const tieB = baseInput({
+    id: "tie-b",
+    source: "https://example.com/tie-b",
+    semantic_score: 0.8,
+  });
+
+  const ranked = evaluateSignals([first, second, tieA, tieB], { now: NOW });
+
+  assert.equal(ranked[0].signal.id, "second");
+  assert.equal(ranked[1].signal.id, "tie-a");
+  assert.equal(ranked[2].signal.id, "tie-b");
+  assert.equal(ranked[3].signal.id, "first");
+});
+
+test("evaluateSignal does not mutate caller-owned inputs", () => {
+  const input = baseInput({ metadata: { nested: { value: 1 } } });
+  const before = JSON.stringify(input);
+
+  const result: CoreSignalEvaluationResult = evaluateSignal(input, { now: NOW });
+
+  assert.equal(JSON.stringify(input), before);
+  assert.notEqual(result.signal.metadata, input.metadata);
+});
+
+test("evaluateSignal public option type is usable by callers", () => {
+  const options: CoreSignalEvaluationOptions = {
+    now: NOW,
+    includeEnvelope: true,
+    includeProvenance: true,
+    provenance: {
+      resultId: "sr_typed",
+      engineVersion: "freshcontext-0.3.17",
+    },
+  };
+
+  const result = evaluateSignal(baseInput(), options);
+
+  assert.ok(result.envelope);
+  assert.ok(result.provenance);
+});


### PR DESCRIPTION
﻿## Summary

Adds a pure Core signal evaluation pipeline that orchestrates FreshContext Core primitives without changing Worker, MCP, D1, cache, runtime, adapter, or feed behavior.

## Changes

- Adds `src/core/pipeline.ts`
- Adds `evaluateSignal(...)`
- Adds `evaluateSignals(...)`
- Adds pipeline-related Core types
- Exports the pipeline from `src/core/index.ts`
- Adds `tests/corePipeline.test.ts`
- Updates `tests/coreApiContract.test.ts`
- Updates `docs/CORE_API.md`
- Updates `npm test` to include the new pipeline tests

## What the pipeline does

The pipeline can:

- normalize signal input
- apply timestamp/failure guard behavior
- compute freshness score
- compute context-conditioned utility as sidecar output
- rank/explain evaluated signals
- optionally create FreshContext envelope output
- optionally prepare Ha-Pri v2 provenance material

## Scope

This is Core-only orchestration.

It does not:

- change Worker behavior
- change MCP runtime behavior
- change cache behavior
- change D1/feed/store wiring
- change adapters
- change package version
- deploy production
- publish npm
- production-wire context utility
- production-enforce Ha-Pri v2

## Validation

- `npm run build`
- `npm test` — 96 passed, 0 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `git diff --check`
- hidden-character scan
- `npm run trust:scan:json` — 0 effective fail findings
