### PR TITLE
Pass 8-D — Core pipeline sidecar-boundary hardening

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -53,6 +53,8 @@ It does not fetch, cache, write D1, inspect Worker bindings, know MCP tool schem
 
 `evaluateSignals` evaluates each input and returns evaluations sorted by existing `rankSignal` final score, preserving input order when scores tie. Context utility is returned as a sidecar and does not replace `final_score`.
 
+Context utility is returned as sidecar output in the current pipeline; it does not replace or modify the default `rankSignal` / `evaluateSignals` ordering. A future pass may add an explicit utility-weighted ranking mode.
+
 ### Stable Types
 
 - `FreshContext`

--- a/tests/corePipeline.test.ts
+++ b/tests/corePipeline.test.ts
@@ -171,6 +171,34 @@ test("evaluateSignals sorts by ranked score and preserves stable tie ordering", 
   assert.equal(ranked[3].signal.id, "first");
 });
 
+test("evaluateSignals sorting follows ranked final_score, not utility sidecar score", () => {
+  const highRankLowUtility = baseInput({
+    id: "high-rank-low-utility",
+    source: "https://example.com/high-rank-low-utility",
+    semantic_score: 0.95,
+    status: "stale",
+  });
+  const lowerRankHighUtility = baseInput({
+    id: "lower-rank-high-utility",
+    source: "https://example.com/lower-rank-high-utility",
+    semantic_score: 0.7,
+    status: "success",
+  });
+
+  const evaluated = evaluateSignals([lowerRankHighUtility, highRankLowUtility], { now: NOW });
+  const highRank = evaluated.find((item) => item.signal.id === "high-rank-low-utility");
+  const lowerRank = evaluated.find((item) => item.signal.id === "lower-rank-high-utility");
+
+  assert.ok(highRank);
+  assert.ok(lowerRank);
+  assert.ok(highRank.ranked.final_score > lowerRank.ranked.final_score);
+  assert.ok(highRank.utility.score < lowerRank.utility.score);
+  assert.equal(evaluated[0].signal.id, "high-rank-low-utility");
+  assert.equal(evaluated[1].signal.id, "lower-rank-high-utility");
+  assert.equal(typeof highRank.utility.score, "number");
+  assert.equal(typeof lowerRank.utility.score, "number");
+});
+
 test("evaluateSignal does not mutate caller-owned inputs", () => {
   const input = baseInput({ metadata: { nested: { value: 1 } } });
   const before = JSON.stringify(input);


### PR DESCRIPTION
﻿## Summary

Pins the current Core pipeline boundary where context utility is returned as sidecar output and does not affect default ranking order.

## Changes

- Adds a regression test proving `evaluateSignals` sorts by `ranked.final_score`, even when another signal has a higher `utility.score`
- Updates `docs/CORE_API.md` to clarify that context utility does not replace or modify default `rankSignal` / `evaluateSignals` ordering

## Scope

Test/docs hardening only.

It does not:
- change Core implementation
- change ranking behavior
- change utility behavior
- touch Worker
- touch MCP runtime
- touch cache
- touch D1/Store/feed
- touch adapters
- implement REST
- deploy
- publish npm
- production-enforce Ha-Pri v2

## Validation

- `npm run build`
- `npm test` — 97 passed, 0 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan on changed files
