### PR TITLE
Pass 8-H — Minimal local REST handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/restHandler.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/rest/handler.ts
+++ b/src/rest/handler.ts
@@ -1,0 +1,161 @@
+import { evaluateSignal, evaluateSignals } from "../core/index.js";
+import type {
+  CoreSignalEvaluationOptions,
+  FreshContextSignalInput,
+} from "../core/index.js";
+
+const SERVICE_VERSION = "0.1.0";
+const JSON_CONTENT_TYPE = "application/json";
+const MAX_BODY_BYTES = 256 * 1024;
+
+type RestErrorCode =
+  | "invalid_request"
+  | "method_not_allowed"
+  | "unsupported_media_type"
+  | "payload_too_large"
+  | "not_found"
+  | "internal_error";
+
+type JsonRecord = Record<string, unknown>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": JSON_CONTENT_TYPE },
+  });
+}
+
+function errorResponse(code: RestErrorCode, message: string, status: number, details: unknown[] = []): Response {
+  return jsonResponse({ error: { code, message, details } }, status);
+}
+
+function methodNotAllowed(allowed: string): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "method_not_allowed",
+        message: `Method not allowed. Use ${allowed}.`,
+        details: [],
+      },
+    }),
+    {
+      status: 405,
+      headers: {
+        "Content-Type": JSON_CONTENT_TYPE,
+        "Allow": allowed,
+      },
+    }
+  );
+}
+
+function isJsonContentType(request: Request): boolean {
+  return (request.headers.get("Content-Type") ?? "").toLowerCase().includes(JSON_CONTENT_TYPE);
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJsonBody(request: Request): Promise<{ ok: true; body: JsonRecord } | { ok: false; response: Response }> {
+  if (!isJsonContentType(request)) {
+    return {
+      ok: false,
+      response: errorResponse("unsupported_media_type", "POST requests require Content-Type: application/json.", 415),
+    };
+  }
+
+  const contentLength = request.headers.get("Content-Length");
+  if (contentLength !== null && Number(contentLength) > MAX_BODY_BYTES) {
+    return {
+      ok: false,
+      response: errorResponse("payload_too_large", `Request body exceeds ${MAX_BODY_BYTES} bytes.`, 413),
+    };
+  }
+
+  const text = await request.text();
+  if (new TextEncoder().encode(text).length > MAX_BODY_BYTES) {
+    return {
+      ok: false,
+      response: errorResponse("payload_too_large", `Request body exceeds ${MAX_BODY_BYTES} bytes.`, 413),
+    };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isRecord(parsed)) {
+      return {
+        ok: false,
+        response: errorResponse("invalid_request", "Request body must be a JSON object.", 400),
+      };
+    }
+    return { ok: true, body: parsed };
+  } catch {
+    return {
+      ok: false,
+      response: errorResponse("invalid_request", "Request body must be valid JSON.", 400),
+    };
+  }
+}
+
+function optionsFromBody(body: JsonRecord): CoreSignalEvaluationOptions | undefined {
+  if (body.options === undefined) return undefined;
+  return isRecord(body.options) ? body.options as CoreSignalEvaluationOptions : {};
+}
+
+async function handleEvaluate(request: Request): Promise<Response> {
+  if (request.method !== "POST") return methodNotAllowed("POST");
+
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+
+  if (!isRecord(parsed.body.signal)) {
+    return errorResponse("invalid_request", "Request body must include signal.", 400);
+  }
+
+  const result = evaluateSignal(
+    parsed.body.signal as unknown as FreshContextSignalInput,
+    optionsFromBody(parsed.body)
+  );
+  return jsonResponse(result);
+}
+
+async function handleEvaluateBatch(request: Request): Promise<Response> {
+  if (request.method !== "POST") return methodNotAllowed("POST");
+
+  const parsed = await readJsonBody(request);
+  if (!parsed.ok) return parsed.response;
+
+  if (!Array.isArray(parsed.body.signals)) {
+    return errorResponse("invalid_request", "Request body must include signals array.", 400);
+  }
+
+  const result = evaluateSignals(
+    parsed.body.signals as unknown as FreshContextSignalInput[],
+    optionsFromBody(parsed.body)
+  );
+  return jsonResponse({ evaluations: result });
+}
+
+function handleHealth(request: Request): Response {
+  if (request.method !== "GET") return methodNotAllowed("GET");
+  return jsonResponse({
+    ok: true,
+    service: "freshcontext-rest",
+    version: SERVICE_VERSION,
+    core_available: true,
+  });
+}
+
+export async function handleRestRequest(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+
+  try {
+    if (url.pathname === "/v1/health") return handleHealth(request);
+    if (url.pathname === "/v1/evaluate") return handleEvaluate(request);
+    if (url.pathname === "/v1/evaluate-batch") return handleEvaluateBatch(request);
+
+    return errorResponse("not_found", `Not found: ${url.pathname}.`, 404);
+  } catch {
+    return errorResponse("internal_error", "Unexpected REST host error.", 500);
+  }
+}

--- a/tests/restHandler.test.ts
+++ b/tests/restHandler.test.ts
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { handleRestRequest } from "../src/rest/handler.js";
+
+const NOW = "2026-05-24T13:00:00.000Z";
+
+function request(path: string, init: RequestInit = {}): Request {
+  return new Request(`https://freshcontext.test${path}`, init);
+}
+
+function jsonRequest(path: string, body: unknown, init: RequestInit = {}): Request {
+  return request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(init.headers ?? {}) },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    ...init,
+  });
+}
+
+async function responseJson(response: Response): Promise<Record<string, any>> {
+  return await response.json() as Record<string, any>;
+}
+
+function signal(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "rest_sig",
+    source: "https://example.com/rest",
+    source_type: "hackernews",
+    title: "REST signal",
+    content: "FreshContext REST handler content",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.9,
+    date_confidence: "high",
+    status: "success",
+    metadata: { route: "rest" },
+    ...overrides,
+  };
+}
+
+test("GET /v1/health returns REST health payload", async () => {
+  const response = await handleRestRequest(request("/v1/health"));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    ok: true,
+    service: "freshcontext-rest",
+    version: "0.1.0",
+    core_available: true,
+  });
+});
+
+test("POST /v1/evaluate returns Core evaluation output", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", {
+    signal: signal(),
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.signal.contract_version, "freshcontext.signal.v1");
+  assert.equal(body.signal.source, "https://example.com/rest");
+  assert.equal(typeof body.freshness_score, "number");
+  assert.equal(typeof body.utility.score, "number");
+  assert.equal(typeof body.ranked.final_score, "number");
+  assert.equal(body.explanation, body.ranked.reason);
+});
+
+test("POST /v1/evaluate-batch returns evaluateSignals ordering", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate-batch", {
+    signals: [
+      signal({ id: "lower", source: "https://example.com/lower", semantic_score: 0.7 }),
+      signal({ id: "higher", source: "https://example.com/higher", semantic_score: 0.95 }),
+    ],
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.evaluations.length, 2);
+  assert.equal(body.evaluations[0].signal.id, "higher");
+  assert.ok(body.evaluations[0].ranked.final_score > body.evaluations[1].ranked.final_score);
+});
+
+test("wrong method returns stable 405 error", async () => {
+  const response = await handleRestRequest(request("/v1/health", { method: "POST" }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 405);
+  assert.equal(response.headers.get("Allow"), "GET");
+  assert.equal(body.error.code, "method_not_allowed");
+  assert.deepEqual(body.error.details, []);
+});
+
+test("non-JSON POST returns stable 415 error", async () => {
+  const response = await handleRestRequest(request("/v1/evaluate", {
+    method: "POST",
+    headers: { "Content-Type": "text/plain" },
+    body: "plain",
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 415);
+  assert.equal(body.error.code, "unsupported_media_type");
+});
+
+test("malformed JSON returns stable 400 error", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", "{not-json"));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.code, "invalid_request");
+});
+
+test("missing signal returns stable 400 error", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", {
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 400);
+  assert.equal(body.error.code, "invalid_request");
+  assert.match(body.error.message, /signal/);
+});
+
+test("missing or non-array signals returns stable 400 error", async () => {
+  const missing = await handleRestRequest(jsonRequest("/v1/evaluate-batch", {
+    options: { now: NOW },
+  }));
+  const nonArray = await handleRestRequest(jsonRequest("/v1/evaluate-batch", {
+    signals: signal(),
+    options: { now: NOW },
+  }));
+
+  assert.equal(missing.status, 400);
+  assert.equal((await responseJson(missing)).error.code, "invalid_request");
+  assert.equal(nonArray.status, 400);
+  assert.equal((await responseJson(nonArray)).error.code, "invalid_request");
+});
+
+test("oversized payload returns stable 413 error", async () => {
+  const largeContent = "x".repeat(260 * 1024);
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", {
+    signal: signal({ content: largeContent }),
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 413);
+  assert.equal(body.error.code, "payload_too_large");
+});
+
+test("unknown route returns stable 404 error", async () => {
+  const response = await handleRestRequest(request("/v1/nope"));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 404);
+  assert.equal(body.error.code, "not_found");
+});
+
+test("failed content remains a valid Core result, not an HTTP error", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", {
+    signal: signal({
+      content: "[ERROR] upstream timeout",
+      semantic_score: 0.99,
+    }),
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.signal.status, "failed");
+  assert.equal(body.freshness_score, null);
+  assert.equal(body.utility.score, 0);
+  assert.equal(body.ranked.confidence, "low");
+});
+
+test("future timestamp remains a valid Core result with reasons, not an HTTP error", async () => {
+  const response = await handleRestRequest(jsonRequest("/v1/evaluate", {
+    signal: signal({
+      published_at: "2026-05-24T13:06:00.000Z",
+      date_confidence: "high",
+    }),
+    options: { now: NOW },
+  }));
+  const body = await responseJson(response);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.signal.published_at, null);
+  assert.equal(body.signal.date_confidence, "unknown");
+  assert.equal(body.freshness_score, null);
+  assert.ok(body.reasons.some((reason: string) => reason.includes("future-dated")));
+});
+
+test("local REST handler does not import Worker, MCP, cache, or D1 surfaces", () => {
+  const source = readFileSync("src/rest/handler.ts", "utf8");
+
+  assert.doesNotMatch(source, /worker\/src|\.\.\/worker|McpServer|WebStandardStreamableHTTPServerTransport/);
+  assert.doesNotMatch(source, /\bD1\b|\bKV\b|\bCACHE\b|\bRATE_LIMITER\b|listen\(/);
+});


### PR DESCRIPTION
## Summary

Adds a minimal local Fetch-style REST handler around FreshContext Core without touching the live Worker, MCP runtime, cache, D1, feeds, or adapters.

## Changes

- Adds `src/rest/handler.ts`
- Adds `handleRestRequest(request: Request): Promise<Response>`
- Adds `tests/restHandler.test.ts`
- Updates `npm test` to include REST handler tests

## Endpoints

- `GET /v1/health`
- `POST /v1/evaluate`
- `POST /v1/evaluate-batch`

## Error handling

Adds stable JSON error responses for:

- `400 invalid_request`
- `404 not_found`
- `405 method_not_allowed`
- `413 payload_too_large`
- `415 unsupported_media_type`
- `500 internal_error`

Uses a conservative local payload cap of `256 KiB`.

## Scope

This is a local REST host primitive only.

It does not:

- add a server listener
- deploy REST
- touch `worker/src/worker.ts`
- touch `src/server.ts`
- touch Worker/MCP runtime
- touch cache behavior
- touch D1/Store/feed wiring
- touch adapters
- add auth, billing, dashboard, webhooks, or tenancy
- production-enforce Ha-Pri v2
- make `utility.score` affect ranking
- publish npm

## Validation

- `npm run build`
- `npm test` — 110 passed, 0 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output
- trailing-whitespace scan on new files — no output

## Focused audits

- No diffs in `worker`, `src/server.ts`, `src/tools`, or `src/adapters`
- `src/rest` has no Worker/MCP/D1/KV/cache imports
- Broader banned-token scan only matched the negative assertion test checking those imports are absent