### PR TITLE
Pass 8-J — Core source profile presets

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -83,6 +83,24 @@ Public exports:
 
 See [Signal Contract v1](./SIGNAL_CONTRACT.md).
 
+## Source Profiles
+
+Source Profiles are early public Core metadata for describing how classes of information age, fail, rank, and explain.
+
+Public exports:
+
+- `BUILT_IN_SOURCE_PROFILES`
+- `getSourceProfile(profileId)`
+- `listSourceProfiles()`
+- `SourceProfile`
+- `SourceProfileId`
+- `SourceAuthorityHint`
+- `SourceDatePolicy`
+- `SourceFailurePolicy`
+- `SourceSurface`
+
+They reframe the 21 MCP tools as reference adapters and source-profile examples instead of the product identity. They do not implement `retrieve(...)`, Operator mode, adapter selection, crawling, local file search, or any host/runtime behavior.
+
 ## Public Ranking Primitives
 
 The ranking primitives are public, but consumers should treat their score scales carefully:

--- a/docs/SOURCE_PROFILES.md
+++ b/docs/SOURCE_PROFILES.md
@@ -1,6 +1,6 @@
 # FreshContext Source Profiles
 
-Status: design only
+Status: early Core metadata
 
 FreshContext is a context gateway for agents and humans before reasoning. It turns raw candidate context into freshness-ranked, explained, provenance-aware context.
 
@@ -59,7 +59,7 @@ adapter output
   -> host response
 ```
 
-They are design policy descriptors, not exported TypeScript in this pass:
+As of Pass 8-J, Core exports built-in profile presets and a small metadata contract shaped like:
 
 ```ts
 type SourceProfile = {
@@ -76,6 +76,15 @@ type SourceProfile = {
 ```
 
 The existing Core `LAMBDA` table is the current decay-policy reference. Source Profiles make that policy understandable and product-facing without changing Core behavior.
+
+Pass 8-J adds:
+
+- `BUILT_IN_SOURCE_PROFILES`
+- `getSourceProfile(profileId)`
+- `listSourceProfiles()`
+- public Source Profile types
+
+It does not add `retrieve(...)`, Operator mode, adapter selection, local file search, crawling, Worker integration, MCP runtime changes, or REST handler changes.
 
 ## Profile Groups
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/restHandler.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export { rankSignals, rankSignal, clampScore } from "./rank.js";
 export { calculateContextUtility } from "./utility.js";
 export { SIGNAL_CONTRACT_VERSION, normalizeSignal } from "./signal.js";
 export { evaluateSignal, evaluateSignals } from "./pipeline.js";
+export { BUILT_IN_SOURCE_PROFILES, getSourceProfile, listSourceProfiles } from "./sourceProfiles.js";
 export {
   canonicalizeHaPriContent,
   sha256Hex,
@@ -20,6 +21,12 @@ export type {
   SignalConfidence,
   SignalDateConfidence,
   SignalContractVersion,
+  SourceAuthorityHint,
+  SourceDatePolicy,
+  SourceFailurePolicy,
+  SourceProfile,
+  SourceProfileId,
+  SourceSurface,
   SignalNormalizeOptions,
   FreshContextSignalInput,
   FreshContextSignal,

--- a/src/core/sourceProfiles.ts
+++ b/src/core/sourceProfiles.ts
@@ -1,0 +1,133 @@
+import { LAMBDA } from "./decay.js";
+import type { SourceProfile, SourceProfileId } from "./types.js";
+
+function halfLifeHours(lambda: number): number {
+  return Number((Math.log(2) / lambda).toFixed(2));
+}
+
+function profile(input: Omit<SourceProfile, "half_life_hours">): SourceProfile {
+  return {
+    ...input,
+    half_life_hours: halfLifeHours(input.default_decay_lambda),
+  };
+}
+
+function copyProfile(profile: SourceProfile): SourceProfile {
+  return {
+    ...profile,
+    source_types: [...profile.source_types],
+    recommended_surfaces: [...profile.recommended_surfaces],
+  };
+}
+
+export const BUILT_IN_SOURCE_PROFILES: Readonly<Record<SourceProfileId, SourceProfile>> = Object.freeze({
+  official_docs: profile({
+    profile_id: "official_docs",
+    source_types: ["official_docs", "changelog", "packagetrends"],
+    purpose: "Official product docs, API docs, standards, changelogs, and canonical source material.",
+    default_decay_lambda: LAMBDA.github,
+    authority_hint: "high",
+    date_policy: "balanced",
+    failure_policy: "warn",
+    recommended_surfaces: ["rest", "sdk", "cli", "operator"],
+  }),
+  code_activity: profile({
+    profile_id: "code_activity",
+    source_types: ["github", "reposearch", "changelog", "packagetrends"],
+    purpose: "Repository activity, release cadence, dependency health, and implementation evidence.",
+    default_decay_lambda: LAMBDA.github,
+    authority_hint: "medium",
+    date_policy: "balanced",
+    failure_policy: "downgrade",
+    recommended_surfaces: ["mcp", "rest", "sdk", "cli", "operator"],
+  }),
+  social_pulse: profile({
+    profile_id: "social_pulse",
+    source_types: ["hackernews", "reddit", "producthunt"],
+    purpose: "Community awareness, social proof, launch momentum, and early-market signal.",
+    default_decay_lambda: LAMBDA.hackernews,
+    authority_hint: "medium",
+    date_policy: "strict",
+    failure_policy: "downgrade",
+    recommended_surfaces: ["mcp", "rest", "sdk", "operator"],
+  }),
+  academic_research: profile({
+    profile_id: "academic_research",
+    source_types: ["google_scholar", "arxiv"],
+    purpose: "Scholarly material, papers, research abstracts, and citation-oriented context.",
+    default_decay_lambda: LAMBDA.arxiv,
+    authority_hint: "high",
+    date_policy: "lenient",
+    failure_policy: "warn",
+    recommended_surfaces: ["mcp", "rest", "sdk", "cli", "operator"],
+  }),
+  market_finance: profile({
+    profile_id: "market_finance",
+    source_types: ["finance", "finance_landscape"],
+    purpose: "Market prices, quotes, financial movement, and finance-specific situational awareness.",
+    default_decay_lambda: LAMBDA.finance,
+    authority_hint: "medium",
+    date_policy: "strict",
+    failure_policy: "exclude",
+    recommended_surfaces: ["mcp", "rest", "sdk", "operator"],
+  }),
+  jobs_opportunities: profile({
+    profile_id: "jobs_opportunities",
+    source_types: ["jobs"],
+    purpose: "Job listings, openings, hiring signals, and opportunity windows.",
+    default_decay_lambda: LAMBDA.jobs,
+    authority_hint: "medium",
+    date_policy: "strict",
+    failure_policy: "downgrade",
+    recommended_surfaces: ["mcp", "rest", "sdk", "cli", "operator"],
+  }),
+  government_regulatory: profile({
+    profile_id: "government_regulatory",
+    source_types: ["govcontracts", "sec_filings", "gebiz", "gdelt", "gov_landscape"],
+    purpose: "Public-sector contracts, official filings, tenders, regulatory disclosures, and global news intelligence.",
+    default_decay_lambda: LAMBDA.govcontracts,
+    authority_hint: "high",
+    date_policy: "strict",
+    failure_policy: "warn",
+    recommended_surfaces: ["mcp", "rest", "sdk", "operator"],
+  }),
+  company_intel: profile({
+    profile_id: "company_intel",
+    source_types: ["yc", "company_landscape"],
+    purpose: "Company research, product velocity, ecosystem activity, and competitive context.",
+    default_decay_lambda: LAMBDA.company_landscape,
+    authority_hint: "medium",
+    date_policy: "balanced",
+    failure_policy: "downgrade",
+    recommended_surfaces: ["mcp", "rest", "sdk", "operator"],
+  }),
+  composite_landscape: profile({
+    profile_id: "composite_landscape",
+    source_types: ["landscape", "idea_landscape", "gov_landscape", "finance_landscape", "company_landscape"],
+    purpose: "Multi-source validation and idea, company, market, government, or finance landscape checks.",
+    default_decay_lambda: LAMBDA.landscape,
+    authority_hint: "medium",
+    date_policy: "balanced",
+    failure_policy: "warn",
+    recommended_surfaces: ["mcp", "rest", "sdk", "operator"],
+  }),
+  local_custom: profile({
+    profile_id: "local_custom",
+    source_types: ["local_custom", "user_provided", "custom"],
+    purpose: "User-provided content and custom signals supplied explicitly by a host or caller.",
+    default_decay_lambda: LAMBDA.default,
+    authority_hint: "medium",
+    date_policy: "balanced",
+    failure_policy: "warn",
+    recommended_surfaces: ["rest", "sdk", "cli", "operator"],
+  }),
+});
+
+export function listSourceProfiles(): SourceProfile[] {
+  return Object.values(BUILT_IN_SOURCE_PROFILES).map(copyProfile);
+}
+
+export function getSourceProfile(profileId: string): SourceProfile | undefined {
+  const profile = BUILT_IN_SOURCE_PROFILES[profileId as SourceProfileId];
+  return profile ? copyProfile(profile) : undefined;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -32,6 +32,21 @@ export interface EnvelopeFormatOptions {
 export type SignalConfidence = "high" | "medium" | "low";
 export type SignalDateConfidence = SignalConfidence | "unknown";
 export type SignalContractVersion = "freshcontext.signal.v1";
+export type SourceAuthorityHint = "high" | "medium" | "low";
+export type SourceDatePolicy = "strict" | "balanced" | "lenient";
+export type SourceFailurePolicy = "exclude" | "downgrade" | "warn";
+export type SourceSurface = "mcp" | "rest" | "sdk" | "cli" | "operator";
+export type SourceProfileId =
+  | "official_docs"
+  | "code_activity"
+  | "social_pulse"
+  | "academic_research"
+  | "market_finance"
+  | "jobs_opportunities"
+  | "government_regulatory"
+  | "company_intel"
+  | "composite_landscape"
+  | "local_custom";
 
 export type ContextUtilityStatus =
   | "success"
@@ -43,6 +58,18 @@ export type ContextUtilityStatus =
 export interface SignalNormalizeOptions {
   defaultSourceType?: string;
   now?: Date | string;
+}
+
+export interface SourceProfile {
+  profile_id: SourceProfileId;
+  source_types: string[];
+  purpose: string;
+  default_decay_lambda: number;
+  half_life_hours: number;
+  authority_hint: SourceAuthorityHint;
+  date_policy: SourceDatePolicy;
+  failure_policy: SourceFailurePolicy;
+  recommended_surfaces: SourceSurface[];
 }
 
 export interface FreshContextSignalInput {

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -4,10 +4,12 @@ import {
   calculateContextUtility,
   calculateHaPriV2,
   calculateFreshnessScore,
+  getSourceProfile,
   explainSignal,
   evaluateSignal,
   evaluateSignals,
   formatForLLM,
+  listSourceProfiles,
   looksLikeFailedAdapterContent,
   normalizeSignal,
   rankSignal,
@@ -33,6 +35,8 @@ import type {
   HaPriV2Result,
   RankedSignal,
   RankOptions,
+  SourceProfile,
+  SourceProfileId,
 } from "../src/core/index.js";
 
 test("public Core API imports compile and callable functions remain available", () => {
@@ -163,3 +167,12 @@ test("public Core evaluation pipeline imports compile and remain callable", () =
   assert.equal(evaluations.length, 1);
 });
 
+test("public source profile imports compile and remain callable", () => {
+  const profileId: SourceProfileId = "official_docs";
+  const profile: SourceProfile | undefined = getSourceProfile(profileId);
+  const profiles: SourceProfile[] = listSourceProfiles();
+
+  assert.ok(profile);
+  assert.equal(profile.profile_id, profileId);
+  assert.ok(profiles.length >= 10);
+});

--- a/tests/sourceProfiles.test.ts
+++ b/tests/sourceProfiles.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  BUILT_IN_SOURCE_PROFILES,
+  getSourceProfile,
+  listSourceProfiles,
+} from "../src/core/index.js";
+import type {
+  SourceAuthorityHint,
+  SourceDatePolicy,
+  SourceFailurePolicy,
+  SourceProfile,
+  SourceProfileId,
+  SourceSurface,
+} from "../src/core/index.js";
+
+test("built-in source profiles have unique profile ids", () => {
+  const profiles = listSourceProfiles();
+  const ids = profiles.map((profile) => profile.profile_id);
+
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test("listSourceProfiles returns all built-in profiles", () => {
+  const profiles = listSourceProfiles();
+
+  assert.equal(profiles.length, Object.keys(BUILT_IN_SOURCE_PROFILES).length);
+  assert.ok(profiles.some((profile) => profile.profile_id === "official_docs"));
+  assert.ok(profiles.some((profile) => profile.profile_id === "local_custom"));
+});
+
+test("getSourceProfile returns known profiles and undefined for unknown ids", () => {
+  const social = getSourceProfile("social_pulse");
+
+  assert.ok(social);
+  assert.equal(social.profile_id, "social_pulse");
+  assert.equal(getSourceProfile("unknown_profile"), undefined);
+});
+
+test("every built-in source profile has usable source types and positive decay metadata", () => {
+  for (const profile of listSourceProfiles()) {
+    assert.ok(profile.source_types.length > 0, `${profile.profile_id} should have source types`);
+    assert.ok(profile.default_decay_lambda > 0, `${profile.profile_id} should have positive lambda`);
+    assert.ok(profile.half_life_hours > 0, `${profile.profile_id} should have positive half-life`);
+  }
+});
+
+test("official docs carry higher authority and slower decay than social pulse", () => {
+  const official = getSourceProfile("official_docs");
+  const social = getSourceProfile("social_pulse");
+
+  assert.ok(official);
+  assert.ok(social);
+  assert.equal(official.authority_hint, "high");
+  assert.ok(official.half_life_hours > social.half_life_hours);
+  assert.ok(official.default_decay_lambda < social.default_decay_lambda);
+});
+
+test("market finance decays faster than academic research", () => {
+  const finance = getSourceProfile("market_finance");
+  const academic = getSourceProfile("academic_research");
+
+  assert.ok(finance);
+  assert.ok(academic);
+  assert.ok(finance.half_life_hours < academic.half_life_hours);
+  assert.ok(finance.default_decay_lambda > academic.default_decay_lambda);
+});
+
+test("local custom exists as explicit caller-provided context, not filesystem access", () => {
+  const local = getSourceProfile("local_custom");
+
+  assert.ok(local);
+  assert.equal(local.profile_id, "local_custom");
+  assert.ok(local.source_types.includes("local_custom"));
+  assert.match(local.purpose, /User-provided/);
+  assert.doesNotMatch(local.purpose, /file search|filesystem|crawler/i);
+});
+
+test("source profile accessors return copies rather than shared mutable arrays", () => {
+  const first = getSourceProfile("official_docs");
+  const second = getSourceProfile("official_docs");
+
+  assert.ok(first);
+  assert.ok(second);
+  first.source_types.push("mutated");
+  first.recommended_surfaces.push("mcp");
+
+  assert.equal(second.source_types.includes("mutated"), false);
+  assert.equal(getSourceProfile("official_docs")?.source_types.includes("mutated"), false);
+});
+
+test("source profile public types are consumable from src/core/index.ts", () => {
+  const profileId: SourceProfileId = "official_docs";
+  const authority: SourceAuthorityHint = "high";
+  const datePolicy: SourceDatePolicy = "balanced";
+  const failurePolicy: SourceFailurePolicy = "warn";
+  const surface: SourceSurface = "sdk";
+  const profile: SourceProfile | undefined = getSourceProfile(profileId);
+
+  assert.ok(profile);
+  assert.equal(profile.authority_hint, authority);
+  assert.equal(profile.date_policy, datePolicy);
+  assert.equal(profile.failure_policy, failurePolicy);
+  assert.ok(profile.recommended_surfaces.includes(surface));
+});


### PR DESCRIPTION
## Summary

Adds Source Profiles as early public Core metadata and built-in presets that reframe the 21 MCP tools as reference adapters, source-profile examples, and proof surfaces rather than the product identity.

## Changes

- Adds `src/core/sourceProfiles.ts`
- Adds public Source Profile types
- Exports Source Profile helpers from `src/core/index.ts`
- Adds built-in source profile presets:
  - `official_docs`
  - `code_activity`
  - `social_pulse`
  - `academic_research`
  - `market_finance`
  - `jobs_opportunities`
  - `government_regulatory`
  - `company_intel`
  - `composite_landscape`
  - `local_custom`
- Adds `tests/sourceProfiles.test.ts`
- Updates Core API contract tests
- Updates `docs/CORE_API.md`
- Updates `docs/SOURCE_PROFILES.md`
- Updates `npm test` to include the new tests

## Scope

This adds Core metadata only.

It does not:

- implement `retrieve(...)`
- implement Operator mode
- change MCP tools
- change adapters
- change Worker/MCP/runtime behavior
- change REST handler behavior
- change Core evaluation behavior
- make `utility.score` affect ranking
- deploy production
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 120 passed, 0 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No diffs in `worker`, `src/server.ts`, `src/tools`, `src/adapters`, or `src/rest`
- No forbidden runtime/import terms in `src/core/sourceProfiles.ts` or `tests/sourceProfiles.test.ts`
- Broader scan only matched docs boundary text saying `retrieve(...)`, Operator, D1, and KV are not implemented or not Core-owned