### PR TITLE
Pass 8-K — Local evaluate demo using source profiles

### DIFF
--- a/examples/evaluate-with-source-profile.ts
+++ b/examples/evaluate-with-source-profile.ts
@@ -1,0 +1,113 @@
+import {
+  evaluateSignals,
+  getSourceProfile,
+} from "../src/core/index.js";
+import type {
+  CoreSignalEvaluationResult,
+  FreshContextSignalInput,
+} from "../src/core/index.js";
+
+const NOW = "2026-05-24T13:00:00.000Z";
+
+const profile = getSourceProfile("academic_research");
+if (!profile) {
+  throw new Error("Built-in academic_research source profile is missing.");
+}
+
+const candidates: FreshContextSignalInput[] = [
+  {
+    id: "paper_recent",
+    source: "https://arxiv.org/abs/2605.12345",
+    source_type: "arxiv",
+    title: "Fresh benchmark for temporal retrieval in agent systems",
+    content: "A recent paper about temporal retrieval evaluation for agent context systems.",
+    published_at: "2026-05-20T09:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.94,
+    date_confidence: "high",
+    status: "success",
+    metadata: { profile_id: profile.profile_id },
+  },
+  {
+    id: "paper_foundational",
+    source: "https://scholar.example.edu/foundational-context-aging",
+    source_type: "google_scholar",
+    title: "Foundational study on information aging and relevance",
+    content: "Older but highly relevant research about how information value changes over time.",
+    published_at: "2022-03-15T00:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.88,
+    date_confidence: "high",
+    status: "success",
+    metadata: { profile_id: profile.profile_id },
+  },
+  {
+    id: "paper_unknown_date",
+    source: "https://research.example.org/context-notes",
+    source_type: "google_scholar",
+    title: "Useful context notes with missing publication date",
+    content: "Relevant notes, but the publication date is missing and should be treated cautiously.",
+    published_at: null,
+    retrieved_at: NOW,
+    semantic_score: 0.78,
+    date_confidence: "unknown",
+    status: "success",
+    metadata: { profile_id: profile.profile_id },
+  },
+  {
+    id: "paper_failed",
+    source: "https://research.example.org/blocked-paper",
+    source_type: "arxiv",
+    title: "Blocked source that should not look fresh",
+    content: "[ERROR] upstream timeout while retrieving paper metadata",
+    published_at: "2026-05-21T09:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.2,
+    date_confidence: "high",
+    status: "success",
+    metadata: { profile_id: profile.profile_id },
+  },
+];
+
+function pct(value: number | null | undefined): string {
+  return typeof value === "number" ? String(value) : "null";
+}
+
+function score(value: number): string {
+  return value.toFixed(3);
+}
+
+function printResult(result: CoreSignalEvaluationResult, index: number): void {
+  console.log(`${index + 1}. ${result.signal.title ?? "Untitled source"}`);
+  console.log(`   Source: ${result.signal.source}`);
+  console.log(`   Freshness: ${pct(result.freshness_score)}`);
+  console.log(`   Final score: ${score(result.ranked.final_score)}`);
+  console.log(`   Utility: ${score(result.utility.score)}`);
+  console.log(`   Confidence: ${result.ranked.confidence}`);
+  console.log(`   Why: ${result.explanation}`);
+
+  if (result.reasons.length > 0) {
+    console.log(`   Warnings: ${result.reasons.join("; ")}`);
+  }
+  console.log("");
+}
+
+const evaluated = evaluateSignals(candidates, {
+  now: NOW,
+  defaultSourceType: profile.source_types[0],
+});
+
+console.log("FreshContext local evaluate demo");
+console.log("Raw candidate context goes in; FreshContext ranks what deserves to reach the model first.");
+console.log("");
+console.log(`Profile: ${profile.profile_id}`);
+console.log(`Purpose: ${profile.purpose}`);
+console.log(`Authority: ${profile.authority_hint}`);
+console.log(`Date policy: ${profile.date_policy}`);
+console.log(`Failure policy: ${profile.failure_policy}`);
+console.log(`Half-life: ${profile.half_life_hours} hours`);
+console.log("");
+console.log("Ranked context:");
+console.log("");
+
+evaluated.forEach(printResult);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "example:ha-pri-v2": "tsx examples/ha-pri-v2-example.ts",
+    "demo:evaluate": "tsx examples/evaluate-with-source-profile.ts",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",


### PR DESCRIPTION
## Summary

Adds a local demo showing how FreshContext evaluates raw candidate context using a built-in Source Profile.

## Changes

- Adds `examples/evaluate-with-source-profile.ts`
- Adds `npm run demo:evaluate`
- Demonstrates `getSourceProfile(academic_research)`
- Demonstrates `evaluateSignals(...)`
- Prints ranked output with freshness, final score, utility, confidence, explanation, and warnings/reasons

## Demo

```bash
npm run demo:evaluate
```

The demo uses four hardcoded academic-style candidate signals:

- fresh academic source
- older but useful source
- missing-date source
- failed/error-looking source

## Scope

Local demo only.

It does not:

- fetch
- read local files
- start a server
- add a listener
- implement `retrieve(...)`
- implement Operator mode
- change Core behavior
- change Worker/MCP/REST/adapters
- touch D1/cache/runtime
- deploy
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 120 passed, 0 skipped
- `npm run demo:evaluate`
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`

## Focused audits

- No diffs in `worker`, `src/server.ts`, `src/tools`, `src/adapters`, `src/rest`, or `src/core`
- No fetch, file reads, server/listener, retrieve, Operator, D1/KV/cache/MCP runtime terms in the demo or package script
- Hidden-character scan: no output