### PR TITLE
Pass 8-M — Core decision helper

### DIFF
--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -101,6 +101,46 @@ Public exports:
 
 They reframe the 21 MCP tools as reference adapters and source-profile examples instead of the product identity. They do not implement `retrieve(...)`, Operator mode, adapter selection, crawling, local file search, or any host/runtime behavior.
 
+## Decision Helper
+
+The decision helper translates a Core evaluation result into user-facing action meaning.
+
+Public exports:
+
+- `interpretEvaluation(evaluation, options?)`
+- `interpretEvaluations(evaluations, options?)`
+- `ContextDecision`
+- `IntentProfileId`
+- `ContextDecisionOptions`
+- `ContextDecisionResult`
+
+Supported decisions:
+
+- `use_first`
+- `cite_as_primary`
+- `cite_as_supporting`
+- `use_as_background`
+- `needs_verification`
+- `needs_refresh`
+- `watch_only`
+- `exclude`
+
+Supported intent profiles:
+
+- `citation_check`
+- `student_research`
+- `developer_adoption`
+- `job_search`
+- `market_watch`
+- `business_due_diligence`
+- `medical_literature_triage`
+
+The helper consumes existing `CoreSignalEvaluationResult` fields plus optional Source Profile metadata. It does not change `evaluateSignal`, `evaluateSignals`, `rankSignal`, ranking order, freshness math, utility math, envelopes, provenance, or host behavior.
+
+FreshContext decisions judge citation readiness, context usefulness, freshness, traceability, and uncertainty. They do not certify truth or provide legal, medical, tax, employment, academic, or investment advice.
+
+Demo output will be updated separately so presentation stays separate from Core decision logic.
+
 ## Public Ranking Primitives
 
 The ranking primitives are public, but consumers should treat their score scales carefully:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/core/decision.ts
+++ b/src/core/decision.ts
@@ -1,0 +1,218 @@
+import { getSourceProfile } from "./sourceProfiles.js";
+import type {
+  ContextDecision,
+  ContextDecisionOptions,
+  ContextDecisionResult,
+  CoreSignalEvaluationResult,
+  IntentProfileId,
+  SourceProfile,
+  SourceProfileId,
+} from "./types.js";
+
+const CITATION_INTENTS = new Set<IntentProfileId>(["citation_check", "student_research"]);
+const STRICT_REFRESH_PROFILES = new Set<SourceProfileId>(["market_finance", "jobs_opportunities"]);
+
+function resolveSourceProfile(profile: ContextDecisionOptions["sourceProfile"]): SourceProfile | undefined {
+  if (!profile) return undefined;
+  return typeof profile === "string" ? getSourceProfile(profile) : profile;
+}
+
+function profileId(profile: SourceProfile | undefined): SourceProfileId | undefined {
+  return profile?.profile_id;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function hasFailureReason(evaluation: CoreSignalEvaluationResult): boolean {
+  return evaluation.reasons.some((reason) => /\b(?:failed|failure|timeout|error|blocked|upstream)\b/i.test(reason));
+}
+
+function isCitationIntent(intent: IntentProfileId | undefined): boolean {
+  return intent !== undefined && CITATION_INTENTS.has(intent);
+}
+
+function nonAdviceWarnings(intent: IntentProfileId | undefined): string[] {
+  switch (intent) {
+    case "citation_check":
+    case "student_research":
+      return ["FreshContext judges citation readiness and context usefulness; it does not certify truth."];
+    case "medical_literature_triage":
+      return ["FreshContext provides literature triage only; it is not medical advice."];
+    case "market_watch":
+      return ["FreshContext provides market signal triage only; it is not investment advice."];
+    case "business_due_diligence":
+      return ["FreshContext supports context triage only; it is not legal, tax, or investment advice."];
+    case "job_search":
+      return ["FreshContext provides opportunity triage only; it is not employment or legal advice."];
+    default:
+      return [];
+  }
+}
+
+function decisionResult(
+  decision: ContextDecision,
+  reasons: string[],
+  warnings: string[]
+): ContextDecisionResult {
+  const copyReasons = unique(reasons);
+  const copyWarnings = unique(warnings);
+
+  switch (decision) {
+    case "use_first":
+      return {
+        decision,
+        label: "Use first",
+        meaning: "This is strong, current context for the task.",
+        action: "Use this near the top of the context bundle.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "cite_as_primary":
+      return {
+        decision,
+        label: "Cite as primary",
+        meaning: "This source is relevant, current, and traceable enough to use as main evidence.",
+        action: "Use it as primary citation evidence, while keeping normal source-review standards.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "cite_as_supporting":
+      return {
+        decision,
+        label: "Cite as supporting",
+        meaning: "This source is useful evidence, but should not be the only or latest support.",
+        action: "Use it as supporting evidence and pair it with stronger or newer sources.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "use_as_background":
+      return {
+        decision,
+        label: "Use as background",
+        meaning: "This source is relevant context, but not strong enough for latest-evidence claims.",
+        action: "Use it for framing, history, or background rather than as the main current source.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "needs_verification":
+      return {
+        decision,
+        label: "Needs verification",
+        meaning: "This source may be useful, but its date, confidence, or traceability is uncertain.",
+        action: "Verify the source details before citing it, acting on it, or sending it to a model as trusted context.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "needs_refresh":
+      return {
+        decision,
+        label: "Needs refresh",
+        meaning: "This source may be useful, but it is too stale or date-uncertain for this source type.",
+        action: "Refresh or re-query this source before relying on it as current context.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "watch_only":
+      return {
+        decision,
+        label: "Watch only",
+        meaning: "This is an interesting signal, but not strong enough to prioritize.",
+        action: "Monitor it or keep it as a weak signal; do not use it as main evidence.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+    case "exclude":
+      return {
+        decision,
+        label: "Exclude",
+        meaning: "This source is failed, too weak, or unsafe to include as useful context.",
+        action: "Keep it out of the final context bundle unless a human explicitly reviews it.",
+        reasons: copyReasons,
+        warnings: copyWarnings,
+      };
+  }
+}
+
+export function interpretEvaluation(
+  evaluation: CoreSignalEvaluationResult,
+  options: ContextDecisionOptions = {}
+): ContextDecisionResult {
+  const sourceProfile = resolveSourceProfile(options.sourceProfile);
+  const sourceProfileId = profileId(sourceProfile);
+  const intentProfile = options.intentProfile;
+  const reasons = unique([
+    evaluation.explanation,
+    ...evaluation.signal.reasons,
+    ...evaluation.utility.reasons,
+    ...evaluation.reasons,
+  ]);
+  const warnings = [...nonAdviceWarnings(intentProfile)];
+  const finalScore = evaluation.ranked.final_score;
+  const utilityScore = evaluation.utility.score;
+  const freshnessScore = evaluation.freshness_score;
+  const confidence = evaluation.ranked.confidence;
+  const isFailed = evaluation.signal.status === "failed"
+    || (confidence === "low" && hasFailureReason(evaluation));
+
+  if (sourceProfile) {
+    reasons.push(`source profile ${sourceProfile.profile_id} uses ${sourceProfile.date_policy} date policy`);
+  }
+  if (intentProfile) {
+    reasons.push(`intent profile ${intentProfile} selected`);
+  }
+
+  if (isFailed) {
+    return decisionResult("exclude", reasons, warnings);
+  }
+
+  if (
+    sourceProfileId
+    && STRICT_REFRESH_PROFILES.has(sourceProfileId)
+    && (freshnessScore === null || freshnessScore < 50)
+  ) {
+    return decisionResult("needs_refresh", reasons, warnings);
+  }
+
+  if (evaluation.signal.date_confidence === "unknown") {
+    if (sourceProfileId === "academic_research" && finalScore >= 0.75) {
+      return decisionResult(isCitationIntent(intentProfile) ? "cite_as_supporting" : "use_as_background", reasons, warnings);
+    }
+    return decisionResult("needs_verification", reasons, warnings);
+  }
+
+  if (
+    finalScore >= 0.85
+    && freshnessScore !== null
+    && freshnessScore >= 70
+    && utilityScore >= 60
+    && confidence === "high"
+  ) {
+    if (sourceProfile?.authority_hint === "high" && isCitationIntent(intentProfile)) {
+      return decisionResult("cite_as_primary", reasons, warnings);
+    }
+    return decisionResult("use_first", reasons, warnings);
+  }
+
+  if (finalScore >= 0.55 && freshnessScore !== null && freshnessScore < 50) {
+    return decisionResult(isCitationIntent(intentProfile) ? "cite_as_supporting" : "use_as_background", reasons, warnings);
+  }
+
+  if (finalScore < 0.35 && utilityScore < 30) {
+    return decisionResult(confidence === "low" ? "exclude" : "watch_only", reasons, warnings);
+  }
+
+  if (finalScore >= 0.55) {
+    return decisionResult("use_as_background", reasons, warnings);
+  }
+
+  return decisionResult("watch_only", reasons, warnings);
+}
+
+export function interpretEvaluations(
+  evaluations: CoreSignalEvaluationResult[],
+  options: ContextDecisionOptions = {}
+): ContextDecisionResult[] {
+  return evaluations.map((evaluation) => interpretEvaluation(evaluation, options));
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export { rankSignals, rankSignal, clampScore } from "./rank.js";
 export { calculateContextUtility } from "./utility.js";
 export { SIGNAL_CONTRACT_VERSION, normalizeSignal } from "./signal.js";
 export { evaluateSignal, evaluateSignals } from "./pipeline.js";
+export { interpretEvaluation, interpretEvaluations } from "./decision.js";
 export { BUILT_IN_SOURCE_PROFILES, getSourceProfile, listSourceProfiles } from "./sourceProfiles.js";
 export {
   canonicalizeHaPriContent,
@@ -27,6 +28,10 @@ export type {
   SourceProfile,
   SourceProfileId,
   SourceSurface,
+  ContextDecision,
+  IntentProfileId,
+  ContextDecisionOptions,
+  ContextDecisionResult,
   SignalNormalizeOptions,
   FreshContextSignalInput,
   FreshContextSignal,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,25 @@ export type SourceProfileId =
   | "composite_landscape"
   | "local_custom";
 
+export type ContextDecision =
+  | "use_first"
+  | "cite_as_primary"
+  | "cite_as_supporting"
+  | "use_as_background"
+  | "needs_verification"
+  | "needs_refresh"
+  | "watch_only"
+  | "exclude";
+
+export type IntentProfileId =
+  | "citation_check"
+  | "student_research"
+  | "developer_adoption"
+  | "job_search"
+  | "market_watch"
+  | "business_due_diligence"
+  | "medical_literature_triage";
+
 export type ContextUtilityStatus =
   | "success"
   | "partial"
@@ -70,6 +89,20 @@ export interface SourceProfile {
   date_policy: SourceDatePolicy;
   failure_policy: SourceFailurePolicy;
   recommended_surfaces: SourceSurface[];
+}
+
+export interface ContextDecisionOptions {
+  sourceProfile?: SourceProfile | SourceProfileId;
+  intentProfile?: IntentProfileId;
+}
+
+export interface ContextDecisionResult {
+  decision: ContextDecision;
+  label: string;
+  meaning: string;
+  action: string;
+  reasons: string[];
+  warnings: string[];
 }
 
 export interface FreshContextSignalInput {

--- a/tests/coreApiContract.test.ts
+++ b/tests/coreApiContract.test.ts
@@ -9,6 +9,8 @@ import {
   evaluateSignal,
   evaluateSignals,
   formatForLLM,
+  interpretEvaluation,
+  interpretEvaluations,
   listSourceProfiles,
   looksLikeFailedAdapterContent,
   normalizeSignal,
@@ -23,6 +25,8 @@ import type {
   AdapterResult,
   ContextUtilityInput,
   ContextUtilityResult,
+  ContextDecisionOptions,
+  ContextDecisionResult,
   CoreSignalEvaluationOptions,
   CoreSignalEvaluationResult,
   EnvelopeFormatOptions,
@@ -175,4 +179,28 @@ test("public source profile imports compile and remain callable", () => {
   assert.ok(profile);
   assert.equal(profile.profile_id, profileId);
   assert.ok(profiles.length >= 10);
+});
+
+test("public decision helper imports compile and remain callable", () => {
+  const evaluation: CoreSignalEvaluationResult = evaluateSignal({
+    source: "https://example.com/decision",
+    source_type: "arxiv",
+    content: "Public Core decision helper contract content",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: "2026-05-24T13:00:00.000Z",
+    semantic_score: 0.9,
+    date_confidence: "high",
+  }, {
+    now: "2026-05-24T13:00:00.000Z",
+  });
+  const options: ContextDecisionOptions = {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  };
+  const decision: ContextDecisionResult = interpretEvaluation(evaluation, options);
+  const decisions: ContextDecisionResult[] = interpretEvaluations([evaluation], options);
+
+  assert.equal(typeof decision.decision, "string");
+  assert.equal(typeof decision.meaning, "string");
+  assert.equal(decisions.length, 1);
 });

--- a/tests/decision.test.ts
+++ b/tests/decision.test.ts
@@ -1,0 +1,236 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateSignal,
+  interpretEvaluation,
+  interpretEvaluations,
+} from "../src/core/index.js";
+import type {
+  ContextDecisionOptions,
+  ContextDecisionResult,
+  CoreSignalEvaluationResult,
+  FreshContextSignalInput,
+} from "../src/core/index.js";
+
+const NOW = "2026-05-24T13:00:00.000Z";
+
+function baseInput(overrides: Partial<FreshContextSignalInput> = {}): FreshContextSignalInput {
+  return {
+    source: "https://example.com/source",
+    source_type: "arxiv",
+    title: "Decision layer source",
+    content: "Relevant FreshContext decision helper source content.",
+    published_at: "2026-05-24T12:00:00.000Z",
+    retrieved_at: NOW,
+    semantic_score: 0.9,
+    date_confidence: "high",
+    status: "success",
+    ...overrides,
+  };
+}
+
+function evaluated(
+  overrides: Partial<FreshContextSignalInput>,
+  options: ContextDecisionOptions
+): { evaluation: CoreSignalEvaluationResult; decision: ContextDecisionResult } {
+  const evaluation = evaluateSignal(baseInput(overrides), { now: NOW });
+  return {
+    evaluation,
+    decision: interpretEvaluation(evaluation, options),
+  };
+}
+
+test("failed evaluation becomes exclude", () => {
+  const { decision } = evaluated({
+    content: "[ERROR] upstream timeout while retrieving metadata",
+    semantic_score: 0.95,
+  }, {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  });
+
+  assert.equal(decision.decision, "exclude");
+  assert.match(decision.meaning, /failed|unsafe|weak/i);
+  assert.match(decision.action, /Keep it out/i);
+});
+
+test("high-quality academic citation check becomes cite_as_primary", () => {
+  const { decision } = evaluated({
+    source: "https://arxiv.org/abs/2605.12345",
+    source_type: "arxiv",
+    semantic_score: 0.94,
+    published_at: "2026-05-20T09:00:00.000Z",
+  }, {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  });
+
+  assert.equal(decision.decision, "cite_as_primary");
+  assert.match(decision.action, /primary citation/i);
+});
+
+test("old academic citation source becomes supporting evidence", () => {
+  const { decision } = evaluated({
+    source: "https://scholar.example.edu/foundational-context-aging",
+    source_type: "google_scholar",
+    semantic_score: 0.88,
+    published_at: "2022-03-15T00:00:00.000Z",
+  }, {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  });
+
+  assert.equal(decision.decision, "cite_as_supporting");
+  assert.match(decision.meaning, /useful evidence/i);
+});
+
+test("missing-date academic source needs verification", () => {
+  const { decision } = evaluated({
+    source: "https://research.example.org/context-notes",
+    source_type: "google_scholar",
+    semantic_score: 0.62,
+    published_at: null,
+    date_confidence: "unknown",
+  }, {
+    sourceProfile: "academic_research",
+    intentProfile: "student_research",
+  });
+
+  assert.equal(decision.decision, "needs_verification");
+  assert.match(decision.action, /Verify/i);
+});
+
+test("market finance with unknown or stale freshness needs refresh", () => {
+  const unknown = evaluated({
+    source_type: "finance",
+    semantic_score: 0.8,
+    published_at: null,
+    date_confidence: "unknown",
+  }, {
+    sourceProfile: "market_finance",
+    intentProfile: "market_watch",
+  });
+  const stale = evaluated({
+    source_type: "finance",
+    semantic_score: 0.8,
+    published_at: "2026-01-01T00:00:00.000Z",
+  }, {
+    sourceProfile: "market_finance",
+    intentProfile: "market_watch",
+  });
+
+  assert.equal(unknown.decision.decision, "needs_refresh");
+  assert.equal(stale.decision.decision, "needs_refresh");
+  assert.match(unknown.decision.warnings.join(" "), /not investment advice/i);
+});
+
+test("jobs opportunities with unknown or stale freshness needs refresh", () => {
+  const unknown = evaluated({
+    source_type: "jobs",
+    semantic_score: 0.75,
+    published_at: null,
+    date_confidence: "unknown",
+  }, {
+    sourceProfile: "jobs_opportunities",
+    intentProfile: "job_search",
+  });
+  const stale = evaluated({
+    source_type: "jobs",
+    semantic_score: 0.75,
+    published_at: "2026-01-01T00:00:00.000Z",
+  }, {
+    sourceProfile: "jobs_opportunities",
+    intentProfile: "job_search",
+  });
+
+  assert.equal(unknown.decision.decision, "needs_refresh");
+  assert.equal(stale.decision.decision, "needs_refresh");
+  assert.match(stale.decision.warnings.join(" "), /not employment or legal advice/i);
+});
+
+test("low-rank social signal becomes watch_only", () => {
+  const { decision } = evaluated({
+    source: "https://news.ycombinator.com/item?id=1",
+    source_type: "hackernews",
+    semantic_score: 0.2,
+    published_at: "2026-05-24T12:00:00.000Z",
+  }, {
+    sourceProfile: "social_pulse",
+    intentProfile: "developer_adoption",
+  });
+
+  assert.equal(decision.decision, "watch_only");
+  assert.match(decision.action, /Monitor/i);
+});
+
+test("interpretEvaluations preserves input order and adds one decision per evaluation", () => {
+  const failed = evaluateSignal(baseInput({
+    content: "[ERROR] upstream failure",
+    semantic_score: 0.95,
+  }), { now: NOW });
+  const strong = evaluateSignal(baseInput({
+    source: "https://arxiv.org/abs/2605.12345",
+    semantic_score: 0.94,
+    published_at: "2026-05-20T09:00:00.000Z",
+  }), { now: NOW });
+
+  const decisions = interpretEvaluations([failed, strong], {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  });
+
+  assert.equal(decisions.length, 2);
+  assert.equal(decisions[0].decision, "exclude");
+  assert.equal(decisions[1].decision, "cite_as_primary");
+});
+
+test("interpretEvaluation does not mutate evaluation", () => {
+  const evaluation = evaluateSignal(baseInput({
+    metadata: { nested: { value: 1 } },
+  }), { now: NOW });
+  const before = JSON.stringify(evaluation);
+
+  interpretEvaluation(evaluation, {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  });
+
+  assert.equal(JSON.stringify(evaluation), before);
+});
+
+test("public decision helper exports are available from src/core/index.ts", () => {
+  const evaluation = evaluateSignal(baseInput(), { now: NOW });
+  const options: ContextDecisionOptions = {
+    sourceProfile: "academic_research",
+    intentProfile: "citation_check",
+  };
+  const decision: ContextDecisionResult = interpretEvaluation(evaluation, options);
+  const decisions: ContextDecisionResult[] = interpretEvaluations([evaluation], options);
+
+  assert.equal(typeof interpretEvaluation, "function");
+  assert.equal(typeof interpretEvaluations, "function");
+  assert.equal(typeof decision.decision, "string");
+  assert.equal(decisions.length, 1);
+});
+
+test("regulated intent wording keeps non-advice boundaries visible", () => {
+  const medical = evaluated({
+    source_type: "google_scholar",
+    published_at: "2026-05-20T00:00:00.000Z",
+    semantic_score: 0.9,
+  }, {
+    sourceProfile: "academic_research",
+    intentProfile: "medical_literature_triage",
+  });
+  const diligence = evaluated({
+    source_type: "company_landscape",
+    published_at: "2026-05-20T00:00:00.000Z",
+    semantic_score: 0.9,
+  }, {
+    sourceProfile: "company_intel",
+    intentProfile: "business_due_diligence",
+  });
+
+  assert.match(medical.decision.warnings.join(" "), /not medical advice/i);
+  assert.match(diligence.decision.warnings.join(" "), /not legal, tax, or investment advice/i);
+});


### PR DESCRIPTION
## Summary

Adds a pure Core decision helper that translates FreshContext evaluation results into user-facing action meaning.

FreshContext should not only rank context. It should say whether a source should be used, cited, refreshed, verified, backgrounded, watched, or excluded.

## Changes

- Adds `src/core/decision.ts`
- Adds public decision helper exports:
  - `interpretEvaluation`
  - `interpretEvaluations`
  - `ContextDecision`
  - `IntentProfileId`
  - `ContextDecisionOptions`
  - `ContextDecisionResult`
- Adds decision labels:
  - `use_first`
  - `cite_as_primary`
  - `cite_as_supporting`
  - `use_as_background`
  - `needs_verification`
  - `needs_refresh`
  - `watch_only`
  - `exclude`
- Adds tests in `tests/decision.test.ts`
- Updates Core API contract tests
- Updates `docs/CORE_API.md`
- Updates `npm test` to include the new decision tests

## Scope

Pure Core helper only.

It does not:

- change Core ranking behavior
- change `evaluateSignal` / `evaluateSignals` behavior
- make `utility.score` affect ordering
- change Source Profile presets
- change demo output
- change Worker
- change MCP tools
- change REST handler
- change adapters
- implement `retrieve(...)`
- implement Operator mode
- deploy
- publish npm
- change package version

## Safety Boundary

FreshContext decisions judge citation readiness, context usefulness, freshness, traceability, and uncertainty.

They do not certify truth or provide legal, medical, tax, employment, academic, or investment advice.

## Validation

- `npm run build`
- `npm test` — 132 passed, 0 skipped
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run demo:evaluate`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No diffs in `worker`, `src/server.ts`, `src/tools`, `src/adapters`, `src/rest`, or `examples`
- No fetch/file read/server/listener/retrieve/runtime terms in `src/core/decision.ts`, `tests/decision.test.ts`, or `package.json`
- Docs only contain expected boundary wording about `retrieve`, Operator, D1, and KV