### PR TITLE
Pass 8-O — Evaluate user-provided source file

### DIFF
--- a/examples/evaluate-file.ts
+++ b/examples/evaluate-file.ts
@@ -1,0 +1,189 @@
+import { readFile } from "node:fs/promises";
+import {
+  evaluateSignals,
+  getSourceProfile,
+  interpretEvaluations,
+} from "../src/core/index.js";
+import type {
+  ContextDecisionResult,
+  CoreSignalEvaluationResult,
+  FreshContextSignalInput,
+  IntentProfileId,
+} from "../src/core/index.js";
+
+const SUPPORTED_INTENTS = new Set<IntentProfileId>([
+  "citation_check",
+  "student_research",
+  "developer_adoption",
+  "job_search",
+  "market_watch",
+  "business_due_diligence",
+  "medical_literature_triage",
+]);
+
+interface SourceFileInput {
+  profile: string;
+  intent: IntentProfileId;
+  signals: FreshContextSignalInput[];
+}
+
+function fail(message: string): never {
+  console.error(`FreshContext input error: ${message}`);
+  process.exit(1);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertStringField(value: Record<string, unknown>, field: string, index?: number): void {
+  if (typeof value[field] !== "string" || value[field] === "") {
+    const prefix = index === undefined ? "" : `signals[${index}].`;
+    fail(`${prefix}${field} must be a non-empty string.`);
+  }
+}
+
+function assertOptionalStringOrNull(value: Record<string, unknown>, field: string, index: number): void {
+  if (value[field] !== undefined && value[field] !== null && typeof value[field] !== "string") {
+    fail(`signals[${index}].${field} must be a string or null when provided.`);
+  }
+}
+
+function assertOptionalNumber(value: Record<string, unknown>, field: string, index: number): void {
+  if (value[field] !== undefined && typeof value[field] !== "number") {
+    fail(`signals[${index}].${field} must be a number when provided.`);
+  }
+}
+
+function validateSignal(value: unknown, index: number): FreshContextSignalInput {
+  if (!isObject(value)) {
+    fail(`signals[${index}] must be an object.`);
+  }
+
+  assertStringField(value, "source", index);
+  assertOptionalStringOrNull(value, "title", index);
+  assertOptionalStringOrNull(value, "content", index);
+  assertOptionalStringOrNull(value, "source_type", index);
+  assertOptionalStringOrNull(value, "published_at", index);
+  assertOptionalStringOrNull(value, "content_date", index);
+  assertOptionalStringOrNull(value, "retrieved_at", index);
+  assertOptionalNumber(value, "semantic_score", index);
+
+  return value as unknown as FreshContextSignalInput;
+}
+
+function validateInput(value: unknown): SourceFileInput {
+  if (!isObject(value)) {
+    fail("JSON root must be an object.");
+  }
+
+  assertStringField(value, "profile");
+  assertStringField(value, "intent");
+
+  if (!SUPPORTED_INTENTS.has(value.intent as IntentProfileId)) {
+    fail(`intent "${String(value.intent)}" is not supported by this demo.`);
+  }
+
+  if (!Array.isArray(value.signals)) {
+    fail("signals must be an array.");
+  }
+  if (value.signals.length === 0) {
+    fail("signals must include at least one source.");
+  }
+
+  return {
+    profile: value.profile as string,
+    intent: value.intent as IntentProfileId,
+    signals: value.signals.map(validateSignal),
+  };
+}
+
+function pct(value: number | null | undefined): string {
+  return typeof value === "number" ? String(value) : "null";
+}
+
+function score(value: number): string {
+  return value.toFixed(3);
+}
+
+function printResult(
+  result: CoreSignalEvaluationResult,
+  decision: ContextDecisionResult,
+  index: number
+): void {
+  console.log(`${index + 1}. ${result.signal.title ?? "Untitled source"}`);
+  console.log(`   Decision: ${decision.label}`);
+  console.log(`   Meaning: ${decision.meaning}`);
+  console.log(`   Action: ${decision.action}`);
+
+  if (decision.warnings.length > 0) {
+    console.log(`   Warnings: ${decision.warnings.join("; ")}`);
+  }
+
+  console.log(`   Source: ${result.signal.source}`);
+  console.log(`   Freshness: ${pct(result.freshness_score)}`);
+  console.log(`   Rank score: ${score(result.ranked.final_score)}`);
+  console.log(`   Utility: ${score(result.utility.score)}`);
+  console.log(`   Confidence: ${result.ranked.confidence}`);
+  console.log(`   Why: ${result.explanation}`);
+
+  if (result.reasons.length > 0) {
+    console.log(`   Signals: ${result.reasons.join("; ")}`);
+  }
+  console.log("");
+}
+
+async function main(): Promise<void> {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    fail("provide a JSON file path, for example: npm run demo:evaluate:file");
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`could not read "${filePath}": ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`could not parse JSON in "${filePath}": ${message}`);
+  }
+
+  const input = validateInput(parsed);
+  const profile = getSourceProfile(input.profile);
+  if (!profile) {
+    fail(`profile "${input.profile}" is not a built-in Source Profile.`);
+  }
+
+  const evaluations = evaluateSignals(input.signals, {
+    defaultSourceType: profile.source_types[0],
+  });
+  const decisions = interpretEvaluations(evaluations, {
+    sourceProfile: profile,
+    intentProfile: input.intent,
+  });
+
+  console.log("FreshContext file evaluate demo");
+  console.log("User-provided candidate context goes in; FreshContext returns decision-ready context.");
+  console.log("");
+  console.log(`Input: ${filePath}`);
+  console.log(`Profile: ${profile.profile_id}`);
+  console.log(`Intent: ${input.intent}`);
+  console.log(`Purpose: ${profile.purpose}`);
+  console.log("");
+  console.log("Decision-ready context:");
+  console.log("");
+
+  evaluations.forEach((result, index) => printResult(result, decisions[index], index));
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+});

--- a/examples/sources.academic.example.json
+++ b/examples/sources.academic.example.json
@@ -1,0 +1,42 @@
+{
+  "profile": "academic_research",
+  "intent": "citation_check",
+  "signals": [
+    {
+      "title": "Fresh benchmark for temporal retrieval in agent systems",
+      "content": "A recent paper about temporal retrieval evaluation for agent context systems.",
+      "source": "https://arxiv.org/abs/2605.12345",
+      "source_type": "arxiv",
+      "published_at": "2026-05-20T09:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.94
+    },
+    {
+      "title": "Foundational study on information aging and relevance",
+      "content": "Older but highly relevant research about how information value changes over time.",
+      "source": "https://scholar.example.edu/foundational-context-aging",
+      "source_type": "google_scholar",
+      "published_at": "2022-03-15T00:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.88
+    },
+    {
+      "title": "Useful context notes with missing publication date",
+      "content": "Relevant notes, but the publication date is missing and should be treated cautiously.",
+      "source": "https://research.example.org/context-notes",
+      "source_type": "google_scholar",
+      "published_at": null,
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.62
+    },
+    {
+      "title": "Blocked source that should not look fresh",
+      "content": "[ERROR] upstream timeout while retrieving paper metadata",
+      "source": "https://research.example.org/blocked-paper",
+      "source_type": "arxiv",
+      "published_at": "2026-05-21T09:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.2
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "example:ha-pri-v2": "tsx examples/ha-pri-v2-example.ts",
     "demo:evaluate": "tsx examples/evaluate-with-source-profile.ts",
+    "demo:evaluate:file": "tsx examples/evaluate-file.ts examples/sources.academic.example.json",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",


### PR DESCRIPTION
## Summary

Adds a local file-input evaluation demo so users can provide their own JSON source list and get FreshContext decisions back.

This is the first practical “use it on my own input” path.

## Changes

* Adds `examples/evaluate-file.ts`
* Adds `examples/sources.academic.example.json`
* Adds `npm run demo:evaluate:file`

## Input shape

```json
{
  profile: academic_research,
  intent: citation_check,
  signals: [
    {
      title: ...,
      content: ...,
      source: ...,
      source_type: arxiv,
      published_at: ...,
      retrieved_at: ...,
      semantic_score: 0.92
    }
  ]
}
```

## Behavior

The demo:

* reads one user-provided JSON file path
* validates root/profile/intent/signals shape without dependencies
* uses `getSourceProfile`
* uses `evaluateSignals`
* uses `interpretEvaluations`
* prints decision-first output

Sample decisions:

* fresh source → `Cite as primary`
* old relevant source → `Cite as supporting`
* missing-date source → `Needs verification`
* failed/error-looking source → `Exclude`

## Error handling

Adds helpful non-zero exits for:

* missing file path
* unreadable file
* malformed JSON
* invalid root
* missing/non-array `signals`
* empty `signals`
* unknown source profile
* unsupported intent
* invalid basic signal fields

## Scope

Local demo only.

It does not:

* implement a full CLI package
* add bin entries
* publish npm
* deploy
* fetch URLs
* crawl
* read directories
* implement `retrieve(...)`
* implement Operator mode
* change Core behavior
* change decision helper behavior
* change ranking behavior
* change Worker
* change MCP tools
* change REST handler
* change adapters
* add dependencies
* change package version

## Validation

* `npm run build`
* `npm test` — 132 passed, 0 skipped
* `npm run demo:evaluate`
* `npm run demo:evaluate:file`
* `npx tsc --noEmit`
* `cd worker && npx tsc --noEmit`
* `npm run smoke:stdio` — 21 tools, v0.3.17
* `npm run trust:scan:json` — 0 effective fail findings
* `git diff --check`
* hidden-character scan — no output

## Focused audit

* No diffs in `worker`, `src/server.ts`, `src/tools`, `src/adapters`, `src/rest`, or `src/core`
* No fetch/crawl/retrieve/Operator/server/listener/D1/KV/cache/MCP runtime terms
* No dependencies added
* No Core behavior changed