### PR TITLE
Pass 8-P — Document bring-your-own-context demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,42 @@ touch ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 ## Usage examples
 
+### Bring your own source list
+
+FreshContext can evaluate candidate context you provide as a local JSON file:
+
+```bash
+npm run demo:evaluate:file
+```
+
+To pass a different file:
+
+```bash
+npm run demo:evaluate:file -- path/to/sources.json
+```
+
+Minimal shape:
+
+```json
+{
+  "profile": "academic_research",
+  "intent": "citation_check",
+  "signals": [
+    {
+      "title": "...",
+      "content": "...",
+      "source": "...",
+      "source_type": "arxiv",
+      "published_at": "...",
+      "retrieved_at": "...",
+      "semantic_score": 0.92
+    }
+  ]
+}
+```
+
+This local demo does not fetch URLs, crawl, or read folders. It evaluates candidate context you provide and returns decision-first output: Decision, Meaning, Action, Warnings, and supporting metrics.
+
 **Should I build this idea?**
 ```
 Use extract_idea_landscape with idea "procurement intelligence saas"

--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -55,6 +55,14 @@ It does not fetch, cache, write D1, inspect Worker bindings, know MCP tool schem
 
 Context utility is returned as sidecar output in the current pipeline; it does not replace or modify the default `rankSignal` / `evaluateSignals` ordering. A future pass may add an explicit utility-weighted ranking mode.
 
+Local demo:
+
+```bash
+npm run demo:evaluate:file -- examples/sources.academic.example.json
+```
+
+The demo reads caller-provided JSON with `profile`, `intent`, and `signals`, then returns decision-first output. It does not fetch URLs, crawl, read folders, deploy REST, or implement Operator mode.
+
 ### Stable Types
 
 - `FreshContext`


### PR DESCRIPTION
## Summary

Documents the bring-your-own-context local demo so users can discover the first practical file-input path.

## Changes

- Adds a `Bring your own source list` section to `README.md`
- Adds a short local demo note to `docs/CORE_API.md`
- Documents `npm run demo:evaluate:file`
- Shows how to pass a custom JSON file
- Shows the minimal `profile` / `intent` / `signals` JSON shape
- Clarifies that the demo does not fetch URLs, crawl, or read folders
- Clarifies that output is decision-first: Decision, Meaning, Action, Warnings, and supporting metrics

## Scope

Documentation only.

It does not:

- change code
- change examples
- change package scripts
- change Core behavior
- change Worker/MCP/REST/adapters
- add commands
- deploy
- publish npm

## Validation

- `git diff --check`
- `npm run demo:evaluate:file`
- `npm test` — 132 passed, 0 skipped
- `npm run trust:scan:json` — 0 effective fail findings
- hidden-character scan — no output

## Focused audit

- Docs-only changes: `README.md`, `docs/CORE_API.md`