### PR TITLE
Pass 8-Q — Jobs bring-your-own-context example

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ To pass a different file:
 npm run demo:evaluate:file -- path/to/sources.json
 ```
 
+Included examples:
+
+```bash
+npm run demo:evaluate:file -- examples/sources.academic.example.json
+npm run demo:evaluate:file -- examples/sources.jobs.example.json
+```
+
 Minimal shape:
 
 ```json

--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -59,6 +59,7 @@ Local demo:
 
 ```bash
 npm run demo:evaluate:file -- examples/sources.academic.example.json
+npm run demo:evaluate:file -- examples/sources.jobs.example.json
 ```
 
 The demo reads caller-provided JSON with `profile`, `intent`, and `signals`, then returns decision-first output. It does not fetch URLs, crawl, read folders, deploy REST, or implement Operator mode.

--- a/examples/evaluate-file.ts
+++ b/examples/evaluate-file.ts
@@ -134,7 +134,7 @@ function printResult(
 }
 
 async function main(): Promise<void> {
-  const filePath = process.argv[2];
+  const filePath = process.argv.slice(2).pop();
   if (!filePath) {
     fail("provide a JSON file path, for example: npm run demo:evaluate:file");
   }

--- a/examples/sources.jobs.example.json
+++ b/examples/sources.jobs.example.json
@@ -1,0 +1,42 @@
+{
+  "profile": "jobs_opportunities",
+  "intent": "job_search",
+  "signals": [
+    {
+      "title": "Fresh remote AI context engineer role",
+      "content": "Sample listing for a remote AI context engineer role focused on retrieval quality, agent workflows, and TypeScript tooling. Application window is open this week.",
+      "source": "https://jobs.example.com/freshcontext-ai-context-engineer",
+      "source_type": "jobs",
+      "published_at": "2026-05-23T09:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.93
+    },
+    {
+      "title": "Older platform engineer opening with agent tooling overlap",
+      "content": "Sample listing for a platform engineer role mentioning agent tooling and internal knowledge systems, but the posting is several months old.",
+      "source": "https://jobs.example.com/older-platform-agent-tooling-role",
+      "source_type": "jobs",
+      "published_at": "2026-01-10T12:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.78
+    },
+    {
+      "title": "Relevant ML research assistant listing with missing date",
+      "content": "Sample listing for an ML research assistant role that looks relevant, but the source does not expose a posting date.",
+      "source": "https://jobs.example.com/ml-research-assistant-no-date",
+      "source_type": "jobs",
+      "published_at": null,
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.7
+    },
+    {
+      "title": "Blocked job board result",
+      "content": "[ERROR] job board blocked request while loading listing details",
+      "source": "https://jobs.example.com/blocked-listing",
+      "source_type": "jobs",
+      "published_at": "2026-05-22T10:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.3
+    }
+  ]
+}


### PR DESCRIPTION
﻿## Summary

Adds a jobs/opportunities bring-your-own-context example and fixes the file-input demo argument override behavior.

This proves the BYOC path works beyond academic citation checking.

## Changes

- Adds `examples/sources.jobs.example.json`
- Updates `examples/evaluate-file.ts` to use the last provided file argument
- Updates `README.md` with a tiny mention of academic + jobs examples
- Updates `docs/CORE_API.md` with a tiny mention of the jobs example

## Jobs sample behavior

The `jobs_opportunities` / `job_search` sample includes:

- fresh strong-fit listing -> `Use first`
- older relevant listing -> `Needs refresh`
- missing-date listing -> `Needs refresh`
- blocked/error listing -> `Exclude`

## Bug fix

Previously:

```bash
npm run demo:evaluate:file -- examples/sources.jobs.example.json
```

still used the default academic example because the package script already supplied `examples/sources.academic.example.json` as the first script argument.

The script now uses the last provided file argument, so both commands work:

```bash
npm run demo:evaluate:file
npm run demo:evaluate:file -- examples/sources.jobs.example.json
```

## Scope

Local example/demo path only.

It does not:

- change Core behavior
- change decision helper behavior
- change ranking behavior
- change Source Profiles
- change Worker
- change MCP tools
- change REST handler
- change adapters
- change package scripts
- implement `retrieve(...)`
- implement Operator mode
- deploy
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 132 passed, 0 skipped
- `npm run demo:evaluate:file`
- `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
- `npm run demo:evaluate`
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio`
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`

## Focused audit

- No diffs in `worker`, `src/server.ts`, `src/tools`, `src/adapters`, `src/rest`, `src/core`, or `package.json`
- Hidden-character scan: no output
- Banned runtime scan only matched existing/docs boundary wording, not new runtime behavior
