### PR TITLE
Pass 8-S — Adapter registry metadata and contract

### DIFF
--- a/docs/SOURCE_PROFILES.md
+++ b/docs/SOURCE_PROFILES.md
@@ -86,6 +86,14 @@ Pass 8-J adds:
 
 It does not add `retrieve(...)`, Operator mode, adapter selection, local file search, crawling, Worker integration, MCP runtime changes, or REST handler changes.
 
+## Adapter Registry Metadata
+
+As of Pass 8-S, the 21 MCP tools are also represented as adapter metadata. The registry maps each current tool name to a future adapter identity, Source Profile, output mode, runtime kind, and migration risk.
+
+This registry is metadata-only. It does not change MCP behavior, adapter implementation behavior, Worker behavior, REST behavior, Core evaluation behavior, or runtime transport. It exists to make future extraction deliberate instead of ad hoc.
+
+The likely first extraction target remains `extract_arxiv`, because it is a low-risk official API style adapter mapped to `academic_research`.
+
 ## Profile Groups
 
 ### Official / Canonical Documentation

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/adapterRegistry.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,0 +1,259 @@
+import type { SourceProfileId } from "../core/index.js";
+
+export type AdapterRisk = "low" | "medium" | "high";
+export type AdapterOutputMode = "single" | "batch" | "composite";
+export type AdapterRuntimeKind = "api" | "browser" | "composite" | "mixed" | "local";
+
+export interface FreshContextAdapterDescriptor {
+  adapter_id: string;
+  tool_name: string;
+  source_profile: SourceProfileId;
+  secondary_source_profiles?: SourceProfileId[];
+  output_mode: AdapterOutputMode;
+  runtime_kind: AdapterRuntimeKind;
+  risk: AdapterRisk;
+  notes?: string;
+}
+
+function descriptor(input: FreshContextAdapterDescriptor): FreshContextAdapterDescriptor {
+  return Object.freeze({
+    ...input,
+    secondary_source_profiles: input.secondary_source_profiles
+      ? Object.freeze([...input.secondary_source_profiles])
+      : undefined,
+  }) as FreshContextAdapterDescriptor;
+}
+
+function copyDescriptor(descriptor: FreshContextAdapterDescriptor): FreshContextAdapterDescriptor {
+  return {
+    ...descriptor,
+    secondary_source_profiles: descriptor.secondary_source_profiles
+      ? [...descriptor.secondary_source_profiles]
+      : undefined,
+  };
+}
+
+export const BUILT_IN_ADAPTER_REGISTRY: readonly FreshContextAdapterDescriptor[] = Object.freeze([
+  descriptor({
+    adapter_id: "github",
+    tool_name: "extract_github",
+    source_profile: "code_activity",
+    output_mode: "single",
+    runtime_kind: "browser",
+    risk: "medium",
+    notes: "Repository page extraction uses browser automation; keep behavior compatibility pinned before signal extraction.",
+  }),
+  descriptor({
+    adapter_id: "google_scholar",
+    tool_name: "extract_scholar",
+    source_profile: "academic_research",
+    output_mode: "batch",
+    runtime_kind: "browser",
+    risk: "medium",
+    notes: "Scholar extraction is browser-backed and date precision is usually year-level.",
+  }),
+  descriptor({
+    adapter_id: "hackernews",
+    tool_name: "extract_hackernews",
+    source_profile: "social_pulse",
+    output_mode: "batch",
+    runtime_kind: "mixed",
+    risk: "medium",
+    notes: "Plain query path uses Algolia API; URL extraction can use browser automation.",
+  }),
+  descriptor({
+    adapter_id: "yc",
+    tool_name: "extract_yc",
+    source_profile: "company_intel",
+    output_mode: "batch",
+    runtime_kind: "browser",
+    risk: "medium",
+    notes: "YC company listing extraction is browser-backed.",
+  }),
+  descriptor({
+    adapter_id: "reposearch",
+    tool_name: "search_repos",
+    source_profile: "code_activity",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "low",
+    notes: "GitHub repository search API result set; good early signal-output candidate.",
+  }),
+  descriptor({
+    adapter_id: "packagetrends",
+    tool_name: "package_trends",
+    source_profile: "code_activity",
+    secondary_source_profiles: ["official_docs"],
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "low",
+    notes: "Registry metadata for npm and PyPI packages.",
+  }),
+  descriptor({
+    adapter_id: "arxiv",
+    tool_name: "extract_arxiv",
+    source_profile: "academic_research",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "low",
+    notes: "Official API with clear paper timestamps; recommended first extraction target.",
+  }),
+  descriptor({
+    adapter_id: "finance",
+    tool_name: "extract_finance",
+    source_profile: "market_finance",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "medium",
+    notes: "Quote freshness and partial-failure semantics need careful compatibility coverage.",
+  }),
+  descriptor({
+    adapter_id: "reddit",
+    tool_name: "extract_reddit",
+    source_profile: "social_pulse",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "medium",
+    notes: "Public JSON API with community-content volatility.",
+  }),
+  descriptor({
+    adapter_id: "producthunt",
+    tool_name: "extract_producthunt",
+    source_profile: "social_pulse",
+    output_mode: "batch",
+    runtime_kind: "mixed",
+    risk: "medium",
+    notes: "Uses optional API path with browser fallback.",
+  }),
+  descriptor({
+    adapter_id: "landscape",
+    tool_name: "extract_landscape",
+    source_profile: "composite_landscape",
+    secondary_source_profiles: ["company_intel", "code_activity", "social_pulse"],
+    output_mode: "composite",
+    runtime_kind: "composite",
+    risk: "high",
+    notes: "Composite report should preserve section-level source profiles before extraction.",
+  }),
+  descriptor({
+    adapter_id: "jobs",
+    tool_name: "search_jobs",
+    source_profile: "jobs_opportunities",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "medium",
+    notes: "Multi-source job aggregation with filters and strict recency expectations.",
+  }),
+  descriptor({
+    adapter_id: "changelog",
+    tool_name: "extract_changelog",
+    source_profile: "official_docs",
+    secondary_source_profiles: ["code_activity"],
+    output_mode: "batch",
+    runtime_kind: "mixed",
+    risk: "medium",
+    notes: "GitHub releases and registry paths are API-backed; website discovery can use browser automation.",
+  }),
+  descriptor({
+    adapter_id: "govcontracts",
+    tool_name: "extract_govcontracts",
+    source_profile: "government_regulatory",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "medium",
+    notes: "Official API; direct API URL compatibility and award-date semantics need coverage.",
+  }),
+  descriptor({
+    adapter_id: "gov_landscape",
+    tool_name: "extract_gov_landscape",
+    source_profile: "composite_landscape",
+    secondary_source_profiles: ["government_regulatory", "code_activity", "social_pulse", "official_docs"],
+    output_mode: "composite",
+    runtime_kind: "composite",
+    risk: "high",
+    notes: "Composite government report stitches multiple source profiles.",
+  }),
+  descriptor({
+    adapter_id: "finance_landscape",
+    tool_name: "extract_finance_landscape",
+    source_profile: "composite_landscape",
+    secondary_source_profiles: ["market_finance", "social_pulse", "code_activity", "official_docs"],
+    output_mode: "composite",
+    runtime_kind: "composite",
+    risk: "high",
+    notes: "Composite finance report must not collapse market and social freshness into one policy.",
+  }),
+  descriptor({
+    adapter_id: "sec_filings",
+    tool_name: "extract_sec_filings",
+    source_profile: "government_regulatory",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "low",
+    notes: "Official SEC API with clear filing dates.",
+  }),
+  descriptor({
+    adapter_id: "gdelt",
+    tool_name: "extract_gdelt",
+    source_profile: "government_regulatory",
+    secondary_source_profiles: ["company_intel"],
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "medium",
+    notes: "Global news intelligence has fast-moving timestamps and broad source variance.",
+  }),
+  descriptor({
+    adapter_id: "company_landscape",
+    tool_name: "extract_company_landscape",
+    source_profile: "composite_landscape",
+    secondary_source_profiles: ["company_intel", "government_regulatory", "market_finance", "official_docs"],
+    output_mode: "composite",
+    runtime_kind: "composite",
+    risk: "high",
+    notes: "Composite company report combines official, market, news, and product velocity signals.",
+  }),
+  descriptor({
+    adapter_id: "gebiz",
+    tool_name: "extract_gebiz",
+    source_profile: "government_regulatory",
+    output_mode: "batch",
+    runtime_kind: "api",
+    risk: "low",
+    notes: "Official data.gov.sg procurement dataset.",
+  }),
+  descriptor({
+    adapter_id: "idea_landscape",
+    tool_name: "extract_idea_landscape",
+    source_profile: "composite_landscape",
+    secondary_source_profiles: ["social_pulse", "company_intel", "code_activity", "jobs_opportunities"],
+    output_mode: "composite",
+    runtime_kind: "composite",
+    risk: "high",
+    notes: "Composite idea validation report stitches social, funding, code, jobs, package, and launch signals.",
+  }),
+]);
+
+export function listAdapterDescriptors(): FreshContextAdapterDescriptor[] {
+  return BUILT_IN_ADAPTER_REGISTRY.map(copyDescriptor);
+}
+
+export function getAdapterDescriptor(adapterIdOrToolName: string): FreshContextAdapterDescriptor | undefined {
+  const descriptor = BUILT_IN_ADAPTER_REGISTRY.find(
+    (item) => item.adapter_id === adapterIdOrToolName || item.tool_name === adapterIdOrToolName
+  );
+  return descriptor ? copyDescriptor(descriptor) : undefined;
+}
+
+export function listAdaptersBySourceProfile(profileId: SourceProfileId): FreshContextAdapterDescriptor[] {
+  return BUILT_IN_ADAPTER_REGISTRY
+    .filter((item) =>
+      item.source_profile === profileId || item.secondary_source_profiles?.includes(profileId)
+    )
+    .map(copyDescriptor);
+}
+
+export function listAdaptersByRisk(risk: AdapterRisk): FreshContextAdapterDescriptor[] {
+  return BUILT_IN_ADAPTER_REGISTRY
+    .filter((item) => item.risk === risk)
+    .map(copyDescriptor);
+}

--- a/tests/adapterRegistry.test.ts
+++ b/tests/adapterRegistry.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  BUILT_IN_ADAPTER_REGISTRY,
+  getAdapterDescriptor,
+  listAdapterDescriptors,
+  listAdaptersByRisk,
+  listAdaptersBySourceProfile,
+} from "../src/adapters/registry.js";
+import type {
+  AdapterOutputMode,
+  AdapterRisk,
+  AdapterRuntimeKind,
+  FreshContextAdapterDescriptor,
+} from "../src/adapters/registry.js";
+import { getSourceProfile } from "../src/core/index.js";
+
+test("registry has 21 descriptors", () => {
+  assert.equal(BUILT_IN_ADAPTER_REGISTRY.length, 21);
+  assert.equal(listAdapterDescriptors().length, 21);
+});
+
+test("adapter ids and tool names are unique", () => {
+  const descriptors = listAdapterDescriptors();
+  const adapterIds = descriptors.map((descriptor) => descriptor.adapter_id);
+  const toolNames = descriptors.map((descriptor) => descriptor.tool_name);
+
+  assert.equal(new Set(adapterIds).size, adapterIds.length);
+  assert.equal(new Set(toolNames).size, toolNames.length);
+});
+
+test("every descriptor maps to an existing SourceProfileId", () => {
+  for (const descriptor of listAdapterDescriptors()) {
+    assert.ok(getSourceProfile(descriptor.source_profile), `${descriptor.adapter_id} should map to a source profile`);
+    for (const secondaryProfile of descriptor.secondary_source_profiles ?? []) {
+      assert.ok(getSourceProfile(secondaryProfile), `${descriptor.adapter_id} secondary profile should exist`);
+    }
+  }
+});
+
+test("extract_arxiv maps to academic_research and low risk", () => {
+  const arxiv = getAdapterDescriptor("extract_arxiv");
+
+  assert.ok(arxiv);
+  assert.equal(arxiv.adapter_id, "arxiv");
+  assert.equal(arxiv.source_profile, "academic_research");
+  assert.equal(arxiv.runtime_kind, "api");
+  assert.equal(arxiv.risk, "low");
+});
+
+test("composite landscape tools are high risk and composite output mode", () => {
+  const compositeTools = [
+    "extract_landscape",
+    "extract_gov_landscape",
+    "extract_finance_landscape",
+    "extract_company_landscape",
+    "extract_idea_landscape",
+  ];
+
+  for (const toolName of compositeTools) {
+    const descriptor = getAdapterDescriptor(toolName);
+
+    assert.ok(descriptor);
+    assert.equal(descriptor.source_profile, "composite_landscape");
+    assert.equal(descriptor.output_mode, "composite");
+    assert.equal(descriptor.runtime_kind, "composite");
+    assert.equal(descriptor.risk, "high");
+  }
+});
+
+test("search_repos maps to code_activity and low risk", () => {
+  const repos = getAdapterDescriptor("search_repos");
+
+  assert.ok(repos);
+  assert.equal(repos.adapter_id, "reposearch");
+  assert.equal(repos.source_profile, "code_activity");
+  assert.equal(repos.risk, "low");
+});
+
+test("search_jobs maps to jobs_opportunities", () => {
+  const jobs = getAdapterDescriptor("search_jobs");
+
+  assert.ok(jobs);
+  assert.equal(jobs.adapter_id, "jobs");
+  assert.equal(jobs.source_profile, "jobs_opportunities");
+});
+
+test("getAdapterDescriptor works by adapter id and tool name", () => {
+  const byId = getAdapterDescriptor("arxiv");
+  const byTool = getAdapterDescriptor("extract_arxiv");
+
+  assert.ok(byId);
+  assert.ok(byTool);
+  assert.deepEqual(byId, byTool);
+  assert.equal(getAdapterDescriptor("unknown_adapter"), undefined);
+});
+
+test("listAdaptersBySourceProfile works", () => {
+  const academic = listAdaptersBySourceProfile("academic_research");
+  const official = listAdaptersBySourceProfile("official_docs");
+
+  assert.ok(academic.some((descriptor) => descriptor.tool_name === "extract_arxiv"));
+  assert.ok(academic.some((descriptor) => descriptor.tool_name === "extract_scholar"));
+  assert.ok(official.some((descriptor) => descriptor.tool_name === "extract_changelog"));
+  assert.ok(official.some((descriptor) => descriptor.tool_name === "package_trends"));
+});
+
+test("listAdaptersByRisk works", () => {
+  const lowRisk = listAdaptersByRisk("low");
+  const highRisk = listAdaptersByRisk("high");
+
+  assert.ok(lowRisk.some((descriptor) => descriptor.adapter_id === "arxiv"));
+  assert.ok(lowRisk.some((descriptor) => descriptor.adapter_id === "reposearch"));
+  assert.ok(highRisk.every((descriptor) => descriptor.output_mode === "composite"));
+});
+
+test("registry accessors return copies rather than shared mutable descriptors", () => {
+  const first = getAdapterDescriptor("landscape");
+  const second = getAdapterDescriptor("landscape");
+
+  assert.ok(first);
+  assert.ok(second);
+  first.secondary_source_profiles?.push("local_custom");
+  first.notes = "mutated";
+
+  assert.equal(second.secondary_source_profiles?.includes("local_custom"), false);
+  assert.notEqual(getAdapterDescriptor("landscape")?.notes, "mutated");
+});
+
+test("registry metadata does not import MCP, Worker, or runtime modules", () => {
+  const registrySource = readFileSync("src/adapters/registry.ts", "utf8");
+
+  assert.doesNotMatch(registrySource, /@modelcontextprotocol|worker\/src|\.\.\/worker|McpServer/);
+  assert.doesNotMatch(registrySource, /fetch\(|createServer|listen\(|D1|KV|CACHE/);
+});
+
+test("adapter registry public types are consumable", () => {
+  const risk: AdapterRisk = "low";
+  const outputMode: AdapterOutputMode = "batch";
+  const runtimeKind: AdapterRuntimeKind = "api";
+  const descriptor: FreshContextAdapterDescriptor | undefined = getAdapterDescriptor("arxiv");
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.risk, risk);
+  assert.equal(descriptor.output_mode, outputMode);
+  assert.equal(descriptor.runtime_kind, runtimeKind);
+});


### PR DESCRIPTION
﻿## Summary

Adds metadata-only adapter registry coverage for the 21 current MCP tools.

This maps the existing tool surface into future adapter assets without changing runtime behavior.

## Changes

- Adds `src/adapters/registry.ts`
- Adds `tests/adapterRegistry.test.ts`
- Updates `docs/SOURCE_PROFILES.md`
- Updates `package.json` test script

## Adapter metadata added

Adds descriptor types:

- `AdapterRisk`
- `AdapterOutputMode`
- `AdapterRuntimeKind`
- `FreshContextAdapterDescriptor`

Adds helpers:

- `BUILT_IN_ADAPTER_REGISTRY`
- `listAdapterDescriptors()`
- `getAdapterDescriptor(adapterIdOrToolName)`
- `listAdaptersBySourceProfile(profileId)`
- `listAdaptersByRisk(risk)`

## Coverage

Adds registry entries for all 21 current MCP tools.

Tests verify:

- registry has 21 descriptors
- adapter IDs are unique
- tool names are unique
- every descriptor maps to an existing Source Profile
- `extract_arxiv` maps to `academic_research` and low risk
- composite tools are high risk and composite mode
- `search_repos` maps to `code_activity` and low risk
- `search_jobs` maps to `jobs_opportunities`
- helper lookups work
- registry accessors return copies
- registry file does not import MCP/Worker/runtime modules

## Scope

Metadata/test/docs only.

It does not:

- extract an adapter
- change adapter implementation behavior
- change MCP tool registration
- change MCP tool schemas
- change Worker
- change REST handler
- change Core evaluation behavior
- change ranking/decision behavior
- implement `retrieve(...)`
- implement Operator mode
- deploy
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 145 passed, 0 skipped
- `npm run demo:evaluate:file`
- `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No diffs in `worker`, `src/server.ts`, `src/tools`, `src/rest`, Core pipeline/decision files, or examples
- The new registry file has no fetch/server/MCP/Worker/runtime behavior
