### PR TITLE
Pass 8-U — Additive arXiv signal extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/adapterRegistry.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/arxivSignals.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/adapterRegistry.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/src/adapters/arxiv.ts
+++ b/src/adapters/arxiv.ts
@@ -1,79 +1,119 @@
 import { AdapterResult, ExtractOptions } from "../types.js";
+import type { FreshContextSignalInput } from "../core/types.js";
+
+export type ArxivSignalSearchInput = {
+  query: string;
+  maxResults?: number;
+  retrievedAt?: string;
+  semanticScore?: number;
+};
+
+type ParsedArxivEntry = {
+  title: string;
+  summary: string;
+  published: string;
+  updated: string;
+  id: string;
+  authors: string[];
+  category: string;
+};
+
+const USER_AGENT = "freshcontext-mcp/0.1.7 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)";
+const DEFAULT_ARXIV_SIGNAL_SCORE = 0.8;
+
+function buildArxivApiUrl(input: string, maxResults = 10): string {
+  const trimmed = input.trim();
+  const safeMaxResults = Number.isFinite(maxResults)
+    ? Math.max(1, Math.min(Math.trunc(maxResults), 50))
+    : 10;
+
+  return trimmed.startsWith("http")
+    ? trimmed
+    : `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(trimmed)}&start=0&max_results=${safeMaxResults}&sortBy=relevance&sortOrder=descending`;
+}
+
+async function fetchArxivXml(apiUrl: string): Promise<string> {
+  const res = await fetch(apiUrl, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!res.ok) throw new Error(`arXiv API error: ${res.status} ${res.statusText}`);
+
+  return res.text();
+}
+
+function getTag(block: string, tag: string): string {
+  const m = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"));
+  return m ? m[1].trim().replace(/\s+/g, " ") : "";
+}
+
+function getAttr(block: string, tag: string, attr: string): string {
+  const m = block.match(new RegExp(`<${tag}[^>]*${attr}="([^"]*)"`, "i"));
+  return m ? m[1].trim() : "";
+}
+
+function normalizeArxivUrl(id: string): string {
+  return id.replace("http://arxiv.org/abs/", "https://arxiv.org/abs/");
+}
+
+function parseArxivEntries(xml: string): ParsedArxivEntry[] {
+  return [...xml.matchAll(/<entry>([\s\S]*?)<\/entry>/g)].map((match) => {
+    const block = match[1];
+    const authorMatches = [...block.matchAll(/<author>([\s\S]*?)<\/author>/g)];
+    const authors = authorMatches
+      .map(a => getTag(a[1], "name"))
+      .filter(Boolean)
+      .slice(0, 4);
+
+    return {
+      title: getTag(block, "title").replace(/\n/g, " "),
+      summary: getTag(block, "summary").replace(/\n/g, " "),
+      published: getTag(block, "published"),
+      updated: getTag(block, "updated"),
+      id: normalizeArxivUrl(getTag(block, "id")),
+      authors,
+      category: getAttr(block, "arxiv:primary_category", "term") ||
+        getAttr(block, "category", "term"),
+    };
+  });
+}
+
+function formatArxivEntry(entry: ParsedArxivEntry, index: number): string {
+  const published = entry.published.slice(0, 10);
+  const updated = entry.updated.slice(0, 10);
+  const authors = entry.authors.join(", ");
+  const summary = entry.summary.slice(0, 300);
+
+  return [
+    `[${index + 1}] ${entry.title}`,
+    `Authors: ${authors || "Unknown"}`,
+    `Published: ${published}${updated !== published ? ` (updated ${updated})` : ""}`,
+    entry.category ? `Category: ${entry.category}` : null,
+    `Abstract: ${summary}\u00e2\u20ac\u00a6`,
+    `Link: ${entry.id}`,
+  ].filter(Boolean).join("\n");
+}
 
 /**
- * arXiv adapter — uses the official arXiv API (no scraping, no auth needed).
+ * arXiv adapter uses the official arXiv API.
  * Accepts a search query or a direct arXiv API URL.
  * Docs: https://arxiv.org/help/api/user-manual
  */
 export async function arxivAdapter(options: ExtractOptions): Promise<AdapterResult> {
   const input = options.url.trim();
-
-  // Build API URL — if they pass a plain query, construct it
-  const apiUrl = input.startsWith("http")
-    ? input
-    : `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(input)}&start=0&max_results=10&sortBy=relevance&sortOrder=descending`;
-
-  const res = await fetch(apiUrl, {
-    headers: { "User-Agent": "freshcontext-mcp/0.1.7 (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)" },
-  });
-
-  if (!res.ok) throw new Error(`arXiv API error: ${res.status} ${res.statusText}`);
-
-  const xml = await res.text();
-
-  // Parse the Atom XML response
-  const entries = [...xml.matchAll(/<entry>([\s\S]*?)<\/entry>/g)];
+  const apiUrl = buildArxivApiUrl(input);
+  const xml = await fetchArxivXml(apiUrl);
+  const entries = parseArxivEntries(xml);
 
   if (!entries.length) {
     return { raw: "No results found for this query.", content_date: null, freshness_confidence: "low" };
   }
 
-  const getTag = (block: string, tag: string): string => {
-    const m = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "i"));
-    return m ? m[1].trim().replace(/\s+/g, " ") : "";
-  };
-
-  const getAttr = (block: string, tag: string, attr: string): string => {
-    const m = block.match(new RegExp(`<${tag}[^>]*${attr}="([^"]*)"`, "i"));
-    return m ? m[1].trim() : "";
-  };
-
-  const papers = entries.map((match, i) => {
-    const block = match[1];
-
-    const title = getTag(block, "title").replace(/\n/g, " ");
-    const summary = getTag(block, "summary").slice(0, 300).replace(/\n/g, " ");
-    const published = getTag(block, "published").slice(0, 10); // YYYY-MM-DD
-    const updated = getTag(block, "updated").slice(0, 10);
-    const id = getTag(block, "id").replace("http://arxiv.org/abs/", "https://arxiv.org/abs/");
-
-    // Authors — can be multiple
-    const authorMatches = [...block.matchAll(/<author>([\s\S]*?)<\/author>/g)];
-    const authors = authorMatches
-      .map(a => getTag(a[1], "name"))
-      .filter(Boolean)
-      .slice(0, 4)
-      .join(", ");
-
-    // Categories
-    const primaryCat = getAttr(block, "arxiv:primary_category", "term") ||
-      getAttr(block, "category", "term");
-
-    return [
-      `[${i + 1}] ${title}`,
-      `Authors: ${authors || "Unknown"}`,
-      `Published: ${published}${updated !== published ? ` (updated ${updated})` : ""}`,
-      primaryCat ? `Category: ${primaryCat}` : null,
-      `Abstract: ${summary}…`,
-      `Link: ${id}`,
-    ].filter(Boolean).join("\n");
-  });
-
+  const papers = entries.map(formatArxivEntry);
   const raw = papers.join("\n\n").slice(0, options.maxLength ?? 6000);
 
-  // Most recent publication date
   const dates = entries
-    .map(m => getTag(m[1], "published").slice(0, 10))
+    .map(entry => entry.published.slice(0, 10))
     .filter(Boolean)
     .sort()
     .reverse();
@@ -81,4 +121,29 @@ export async function arxivAdapter(options: ExtractOptions): Promise<AdapterResu
   const content_date = dates[0] ?? null;
 
   return { raw, content_date, freshness_confidence: content_date ? "high" : "medium" };
+}
+
+export async function searchArxivSignals(input: ArxivSignalSearchInput): Promise<FreshContextSignalInput[]> {
+  const query = input.query.trim();
+  const apiUrl = buildArxivApiUrl(query, input.maxResults);
+  const xml = await fetchArxivXml(apiUrl);
+  const entries = parseArxivEntries(xml);
+  const retrievedAt = input.retrievedAt ?? new Date().toISOString();
+  const semanticScore = input.semanticScore ?? DEFAULT_ARXIV_SIGNAL_SCORE;
+
+  return entries.map((entry): FreshContextSignalInput => ({
+    title: entry.title,
+    content: entry.summary,
+    source: entry.id,
+    source_type: "arxiv",
+    published_at: entry.published || null,
+    retrieved_at: retrievedAt,
+    semantic_score: semanticScore,
+    metadata: {
+      authors: entry.authors,
+      category: entry.category || null,
+      updated_at: entry.updated || null,
+      query,
+    },
+  }));
 }

--- a/tests/arxivSignals.test.ts
+++ b/tests/arxivSignals.test.ts
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { arxivAdapter, searchArxivSignals } from "../src/adapters/arxiv.js";
+
+const ARXIV_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2605.12345v1</id>
+    <updated>2026-05-12T13:45:00Z</updated>
+    <published>2026-05-10T09:30:00Z</published>
+    <title>FreshContext temporal retrieval benchmark</title>
+    <summary>
+      A paper about freshness-ranked context selection for agent systems.
+    </summary>
+    <author><name>Ada Lovelace</name></author>
+    <author><name>Grace Hopper</name></author>
+    <arxiv:primary_category xmlns:arxiv="http://arxiv.org/schemas/atom" term="cs.AI" />
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2501.99999v2</id>
+    <updated>2025-02-01T00:00:00Z</updated>
+    <published>2025-01-15T00:00:00Z</published>
+    <title>Context aging in retrieval systems</title>
+    <summary>Older but relevant retrieval context work.</summary>
+    <author><name>Alan Turing</name></author>
+    <category term="cs.IR" />
+  </entry>
+</feed>`;
+
+const EMPTY_ARXIV_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>arXiv Query: no results</title>
+</feed>`;
+
+function installFetch(response: Response, urls: string[] = []): () => void {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input: string | URL | Request) => {
+    urls.push(String(input));
+    return response.clone();
+  };
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+test("searchArxivSignals maps arXiv XML entries to FreshContextSignalInput", async () => {
+  const requestedUrls: string[] = [];
+  const restoreFetch = installFetch(new Response(ARXIV_FIXTURE, { status: 200 }), requestedUrls);
+
+  try {
+    const signals = await searchArxivSignals({
+      query: "temporal retrieval",
+      retrievedAt: "2026-06-02T10:00:00.000Z",
+      semanticScore: 0.93,
+    });
+
+    assert.equal(requestedUrls.length, 1);
+    assert.match(requestedUrls[0], /^https:\/\/export\.arxiv\.org\/api\/query\?/);
+    assert.match(requestedUrls[0], /search_query=all:temporal%20retrieval/);
+    assert.equal(signals.length, 2);
+
+    assert.equal(signals[0].title, "FreshContext temporal retrieval benchmark");
+    assert.equal(signals[0].content, "A paper about freshness-ranked context selection for agent systems.");
+    assert.equal(signals[0].source, "https://arxiv.org/abs/2605.12345v1");
+    assert.equal(signals[0].source_type, "arxiv");
+    assert.equal(signals[0].published_at, "2026-05-10T09:30:00Z");
+    assert.equal(signals[0].retrieved_at, "2026-06-02T10:00:00.000Z");
+    assert.equal(signals[0].semantic_score, 0.93);
+    assert.deepEqual(signals[0].metadata?.authors, ["Ada Lovelace", "Grace Hopper"]);
+    assert.equal(signals[0].metadata?.category, "cs.AI");
+    assert.equal(signals[0].metadata?.updated_at, "2026-05-12T13:45:00Z");
+    assert.equal(signals[0].metadata?.query, "temporal retrieval");
+
+    assert.equal(signals[1].source, "https://arxiv.org/abs/2501.99999v2");
+    assert.equal(signals[1].metadata?.category, "cs.IR");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("searchArxivSignals respects direct API URLs, retrievedAt, semanticScore, and maxResults", async () => {
+  const requestedUrls: string[] = [];
+  const restoreFetch = installFetch(new Response(ARXIV_FIXTURE, { status: 200 }), requestedUrls);
+
+  try {
+    const signals = await searchArxivSignals({
+      query: "https://export.arxiv.org/api/query?search_query=all:test",
+      maxResults: 3,
+      retrievedAt: "2026-06-02T11:00:00.000Z",
+      semanticScore: 0.67,
+    });
+
+    assert.equal(requestedUrls[0], "https://export.arxiv.org/api/query?search_query=all:test");
+    assert.equal(signals[0].retrieved_at, "2026-06-02T11:00:00.000Z");
+    assert.equal(signals[0].semantic_score, 0.67);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("searchArxivSignals defaults retrieved_at and semantic_score for signal output", async () => {
+  const restoreFetch = installFetch(new Response(ARXIV_FIXTURE, { status: 200 }));
+
+  try {
+    const before = Date.now();
+    const signals = await searchArxivSignals({ query: "context freshness" });
+    const after = Date.now();
+
+    assert.equal(signals[0].semantic_score, 0.8);
+    assert.ok(signals[0].retrieved_at);
+
+    const retrievedAt = Date.parse(signals[0].retrieved_at ?? "");
+    assert.ok(retrievedAt >= before - 1000);
+    assert.ok(retrievedAt <= after + 1000);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("searchArxivSignals returns an empty signal list for no-results XML", async () => {
+  const restoreFetch = installFetch(new Response(EMPTY_ARXIV_FIXTURE, { status: 200 }));
+
+  try {
+    const signals = await searchArxivSignals({ query: "freshcontext no result fixture" });
+    assert.deepEqual(signals, []);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("searchArxivSignals rejects predictably on arXiv API failure", async () => {
+  const restoreFetch = installFetch(new Response("too many requests", {
+    status: 429,
+    statusText: "Too Many Requests",
+  }));
+
+  try {
+    await assert.rejects(
+      searchArxivSignals({ query: "rate limited" }),
+      /arXiv API error: 429 Too Many Requests/,
+    );
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("arxivAdapter still returns aggregate AdapterResult shape from the same fixture", async () => {
+  const restoreFetch = installFetch(new Response(ARXIV_FIXTURE, { status: 200 }));
+
+  try {
+    const result = await arxivAdapter({ url: "temporal retrieval", maxLength: 6000 });
+
+    assert.match(result.raw, /\[1\] FreshContext temporal retrieval benchmark/);
+    assert.match(result.raw, /Authors: Ada Lovelace, Grace Hopper/);
+    assert.match(result.raw, /Published: 2026-05-10 \(updated 2026-05-12\)/);
+    assert.match(result.raw, /Category: cs.AI/);
+    assert.match(result.raw, /Link: https:\/\/arxiv\.org\/abs\/2605\.12345v1/);
+    assert.equal(result.content_date, "2026-05-10");
+    assert.equal(result.freshness_confidence, "high");
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("arxivAdapter keeps no-results AdapterResult behavior", async () => {
+  const restoreFetch = installFetch(new Response(EMPTY_ARXIV_FIXTURE, { status: 200 }));
+
+  try {
+    const result = await arxivAdapter({ url: "no results" });
+
+    assert.equal(result.raw, "No results found for this query.");
+    assert.equal(result.content_date, null);
+    assert.equal(result.freshness_confidence, "low");
+  } finally {
+    restoreFetch();
+  }
+});


### PR DESCRIPTION
﻿## Summary

Adds an additive arXiv signal extraction path without changing the existing MCP `extract_arxiv` behavior.

This is the first adapter extraction step toward the new adapter -> Source Profile -> Core evaluation framework.

## Changes

- Adds `searchArxivSignals(input): Promise<FreshContextSignalInput[]>`
- Adds `ArxivSignalSearchInput`
- Keeps existing `arxivAdapter(...)` exported and compatible
- Reuses arXiv XML parsing for both old aggregate output and new signal output
- Adds `tests/arxivSignals.test.ts`
- Updates `npm test` to include the new arXiv signal tests

## New signal output

Each arXiv paper maps to `FreshContextSignalInput` with:

- `title`
- `content`
- `source`
- `source_type: "arxiv"`
- `published_at`
- `retrieved_at`
- `semantic_score`
- `metadata`

Metadata includes, where available:

- `authors`
- `category`
- `updated_at`
- `query`

## Scope

Additive adapter signal path only.

It does not:

- remove or rewrite `arxivAdapter(...)`
- change `src/server.ts`
- change MCP tool registration
- change MCP schemas
- change Worker
- change REST handler
- change Core behavior
- change ranking/decision behavior
- change adapter registry
- change examples
- implement `retrieve(...)`
- implement Operator mode
- deploy
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 152 passed, 0 skipped
- `npm run demo:evaluate:file`
- `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No diffs in `src/server.ts`, Worker, REST, Core, registry, or examples
- Existing `arxivAdapter(...)` behavior remains compatible
- New signal path is tested with mocked fetch
