### PR TITLE
Pass 8-V — arXiv signal-to-decision proof

### DIFF
--- a/examples/evaluate-arxiv-signals.ts
+++ b/examples/evaluate-arxiv-signals.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { searchArxivSignals } from "../src/adapters/arxiv.js";
+import {
+  evaluateSignals,
+  getSourceProfile,
+  interpretEvaluations,
+} from "../src/core/index.js";
+import type {
+  ContextDecisionResult,
+  CoreSignalEvaluationResult,
+} from "../src/core/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(__dirname, "fixtures/arxiv-sample.xml");
+const FIXTURE_XML = readFileSync(FIXTURE_PATH, "utf8");
+const NOW = "2026-06-02T12:00:00.000Z";
+
+const profile = getSourceProfile("academic_research");
+if (!profile) {
+  throw new Error("Built-in academic_research source profile is missing.");
+}
+
+function installFixtureFetch(): () => void {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => new Response(FIXTURE_XML, {
+    status: 200,
+    headers: { "Content-Type": "application/atom+xml" },
+  });
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+function pct(value: number | null | undefined): string {
+  return typeof value === "number" ? String(value) : "null";
+}
+
+function score(value: number): string {
+  return value.toFixed(3);
+}
+
+function printResult(
+  result: CoreSignalEvaluationResult,
+  decision: ContextDecisionResult,
+  index: number
+): void {
+  console.log(`${index + 1}. ${result.signal.title ?? "Untitled arXiv source"}`);
+  console.log(`   Decision: ${decision.label}`);
+  console.log(`   Meaning: ${decision.meaning}`);
+  console.log(`   Action: ${decision.action}`);
+
+  if (decision.warnings.length > 0) {
+    console.log(`   Warnings: ${decision.warnings.join("; ")}`);
+  }
+
+  console.log(`   Source: ${result.signal.source}`);
+  console.log(`   Freshness: ${pct(result.freshness_score)}`);
+  console.log(`   Rank score: ${score(result.ranked.final_score)}`);
+  console.log(`   Utility: ${score(result.utility.score)}`);
+  console.log(`   Confidence: ${result.ranked.confidence}`);
+  console.log(`   Why: ${result.explanation}`);
+  console.log("");
+}
+
+async function main(): Promise<void> {
+  const restoreFetch = installFixtureFetch();
+
+  try {
+    const signals = await searchArxivSignals({
+      query: "freshness-ranked context selection",
+      retrievedAt: NOW,
+      semanticScore: 0.96,
+    });
+    const evaluations = evaluateSignals(signals, {
+      now: NOW,
+      defaultSourceType: "arxiv",
+    });
+    const decisions = interpretEvaluations(evaluations, {
+      sourceProfile: profile,
+      intentProfile: "citation_check",
+    });
+
+    console.log("arXiv signal extraction demo");
+    console.log("arXiv XML -> FreshContext signals -> Core decisions");
+    console.log("");
+    console.log(`Profile: ${profile.profile_id}`);
+    console.log(`Purpose: ${profile.purpose}`);
+    console.log("");
+    console.log("Decision-ready arXiv context:");
+    console.log("");
+
+    evaluations.forEach((result, index) => printResult(result, decisions[index], index));
+  } finally {
+    restoreFetch();
+  }
+}
+
+await main();

--- a/examples/fixtures/arxiv-sample.xml
+++ b/examples/fixtures/arxiv-sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/2605.12345v1</id>
+    <updated>2026-05-25T12:00:00Z</updated>
+    <published>2026-05-25T12:00:00Z</published>
+    <title>FreshContext temporal retrieval benchmark</title>
+    <summary>
+      A current paper about freshness-ranked context selection and citation-ready evidence for agent systems.
+    </summary>
+    <author><name>Ada Lovelace</name></author>
+    <author><name>Grace Hopper</name></author>
+    <arxiv:primary_category xmlns:arxiv="http://arxiv.org/schemas/atom" term="cs.AI" />
+  </entry>
+  <entry>
+    <id>http://arxiv.org/abs/2410.54321v2</id>
+    <updated>2024-11-10T09:00:00Z</updated>
+    <published>2024-10-15T09:00:00Z</published>
+    <title>Information aging in retrieval augmented systems</title>
+    <summary>
+      Older but relevant work on how retrieved information decays over time in model context windows.
+    </summary>
+    <author><name>Alan Turing</name></author>
+    <category term="cs.IR" />
+  </entry>
+</feed>

--- a/package.json
+++ b/package.json
@@ -37,13 +37,14 @@
     "start": "node dist/server.js",
     "inspect": "npx @modelcontextprotocol/inspector tsx src/server.ts",
     "example:ha-pri-v2": "tsx examples/ha-pri-v2-example.ts",
+    "demo:arxiv": "tsx examples/evaluate-arxiv-signals.ts",
     "demo:evaluate": "tsx examples/evaluate-with-source-profile.ts",
     "demo:evaluate:file": "tsx examples/evaluate-file.ts examples/sources.academic.example.json",
     "smoke:stdio": "node scripts/smoke-stdio.mjs",
     "trust:scan": "node scripts/trust-scan.mjs",
     "trust:scan:json": "node scripts/trust-scan.mjs --json",
     "trust:scan:markdown": "node scripts/trust-scan.mjs --markdown",
-    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/arxivSignals.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/adapterRegistry.test.ts tests/trustScan.test.mjs"
+    "test": "tsx --test tests/freshnessStamp.test.ts tests/hackernews.test.ts tests/arxivSignals.test.ts tests/arxivDecisionIntegration.test.ts tests/core.test.ts tests/rank.test.ts tests/workerEnvelope.test.ts tests/workerCoreEnvelopeParity.test.ts tests/coreEnvelopeOptions.test.ts tests/mathSpine.test.ts tests/coreApiContract.test.ts tests/corePipeline.test.ts tests/decision.test.ts tests/restHandler.test.ts tests/sourceProfiles.test.ts tests/adapterRegistry.test.ts tests/trustScan.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/tests/arxivDecisionIntegration.test.ts
+++ b/tests/arxivDecisionIntegration.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { searchArxivSignals } from "../src/adapters/arxiv.js";
+import { evaluateSignals } from "../src/core/pipeline.js";
+import { interpretEvaluations } from "../src/core/decision.js";
+import { getSourceProfile } from "../src/core/sourceProfiles.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = resolve(__dirname, "../examples/fixtures/arxiv-sample.xml");
+const FIXTURE_XML = readFileSync(FIXTURE_PATH, "utf8");
+const NOW = "2026-06-02T12:00:00.000Z";
+
+function installArxivFixtureFetch(): () => void {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => new Response(FIXTURE_XML, {
+    status: 200,
+    headers: { "Content-Type": "application/atom+xml" },
+  });
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+test("arXiv signal extraction feeds Core evaluation and decision helper", async () => {
+  const restoreFetch = installArxivFixtureFetch();
+
+  try {
+    const sourceProfile = getSourceProfile("academic_research");
+    assert.ok(sourceProfile);
+
+    const signals = await searchArxivSignals({
+      query: "freshness-ranked context selection",
+      retrievedAt: NOW,
+      semanticScore: 0.96,
+    });
+    const evaluations = evaluateSignals(signals, {
+      now: NOW,
+      defaultSourceType: "arxiv",
+    });
+    const decisions = interpretEvaluations(evaluations, {
+      sourceProfile,
+      intentProfile: "citation_check",
+    });
+
+    assert.equal(signals.length, 2);
+    assert.equal(evaluations.length, 2);
+    assert.equal(decisions.length, 2);
+
+    assert.equal(evaluations[0].signal.title, "FreshContext temporal retrieval benchmark");
+    assert.equal(evaluations[0].signal.source_type, "arxiv");
+    assert.equal(evaluations[0].signal.published_at, "2026-05-25T12:00:00.000Z");
+    assert.ok((evaluations[0].freshness_score ?? 0) >= 90);
+    assert.ok(evaluations[0].ranked.final_score >= 0.85);
+    assert.ok(evaluations[0].utility.score >= 60);
+
+    assert.equal(decisions[0].decision, "cite_as_primary");
+    assert.match(decisions[0].meaning, /main evidence/i);
+    assert.match(decisions[0].action, /primary citation evidence/i);
+    assert.ok(decisions[0].warnings.some((warning) => /does not certify truth/i.test(warning)));
+
+    assert.equal(evaluations[1].signal.title, "Information aging in retrieval augmented systems");
+    assert.equal(decisions[1].decision, "cite_as_supporting");
+    assert.ok(decisions[1].warnings.some((warning) => /does not certify truth/i.test(warning)));
+  } finally {
+    restoreFetch();
+  }
+});
+
+test("arXiv decision proof does not require MCP server behavior", async () => {
+  const source = readFileSync(resolve(__dirname, "../src/server.ts"), "utf8");
+
+  assert.match(source, /arxivAdapter/);
+  assert.doesNotMatch(source, /searchArxivSignals/);
+});


### PR DESCRIPTION
﻿## Summary

Closes the loop for the first extracted adapter path.

This proves:

```txt
arXiv XML
-> searchArxivSignals(...)
-> evaluateSignals(...)
-> interpretEvaluations(...)
-> decision-ready output
```

## Changes

- Adds `tests/arxivDecisionIntegration.test.ts`
- Adds `examples/evaluate-arxiv-signals.ts`
- Adds `examples/fixtures/arxiv-sample.xml`
- Adds `npm run demo:arxiv`

## Demo

```bash
npm run demo:arxiv
```

The demo uses a static fixture-backed mocked fetch. It does not require live network access.

Sample output leads with decisions such as:

- `Cite as primary`
- `Cite as supporting`

## Scope

Adapter-to-Core proof only.

It does not:

- extract another adapter
- change `arxivAdapter(...)` behavior
- change `searchArxivSignals(...)` behavior
- change `src/server.ts`
- change MCP tool registration
- change Worker
- change REST handler
- change Core behavior
- change ranking/decision behavior
- change adapter registry
- implement `retrieve(...)`
- implement Operator mode
- deploy
- publish npm
- change package version

## Validation

- `npm run build`
- `npm test` — 154 passed, 0 skipped
- `npm run demo:arxiv`
- `npm run demo:evaluate:file`
- `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm run smoke:stdio` — 21 tools, v0.3.17
- `npm run trust:scan:json` — 0 effective fail findings
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No `src/server.ts`, Worker, REST, Core, registry, or existing BYOC sample changes
- No live network required
- Old MCP arXiv path untouched
