### PR TITLE
Pass 8-X — Package surface hardening

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -46,7 +46,9 @@ docs/STRATEGIC_BRIEF.md
 docs/TARGET_LIST_AND_OUTREACH_PLAN.md
 docs/TRUST_ROADMAP.md
 
-# Repo-only smoke/demo/development helpers
+# Repo-only tests, examples, smoke/demo/development helpers
+tests/
+examples/
 scripts/
 demo/
 cleanup.ps1

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ touch ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 ## Usage examples
 
+The `npm run demo:*` commands below are source-checkout workflows for contributors and evaluators using a cloned repository. The published npm package is the MCP server/runtime package and does not include repo-only source examples or tests.
+
 ### Bring your own source list
 
 FreshContext can evaluate candidate context you provide as a local JSON file:

--- a/docs/CODEX_MCP_USAGE.md
+++ b/docs/CODEX_MCP_USAGE.md
@@ -9,12 +9,12 @@ Codex can launch FreshContext as a local MCP server over stdio.
 The verified local server entrypoint is:
 
 ```powershell
-& 'C:\Program Files\nodejs\node.exe' 'C:\Users\Immanuel Gabriel\Downloads\freshcontext-mcp\dist\server.js'
+& '<node-executable>' '<repo-root>\dist\server.js'
 ```
 
 The MCP server exposes 21 tools. The local smoke test verifies the package version, server version, expected tool count, and representative tool calls.
 
-No API key is required for the local stdio smoke path.
+No credential is required for the local stdio smoke path.
 
 ## Local stdio setup
 
@@ -27,18 +27,18 @@ Prerequisites:
 From the repository root:
 
 ```powershell
-cd 'C:\Users\Immanuel Gabriel\Downloads\freshcontext-mcp'
+cd '<repo-root>'
 npm install
 npm run build
 npm run smoke:stdio
 ```
 
-For this machine, the Codex MCP command should use the same Node executable and built server path validated by the smoke test:
+For a local Codex setup, use the same Node executable and built server path validated by the smoke test:
 
 ```toml
 [mcp_servers.freshcontext]
-command = 'C:\Program Files\nodejs\node.exe'
-args = ['C:\Users\Immanuel Gabriel\Downloads\freshcontext-mcp\dist\server.js']
+command = '<node-executable>'
+args = ['<repo-root>\dist\server.js']
 ```
 
 A more portable variant is also valid when `node` is available on Codex's PATH:
@@ -46,7 +46,7 @@ A more portable variant is also valid when `node` is available on Codex's PATH:
 ```toml
 [mcp_servers.freshcontext]
 command = "node"
-args = ['C:\Users\Immanuel Gabriel\Downloads\freshcontext-mcp\dist\server.js']
+args = ['<repo-root>\dist\server.js']
 ```
 
 Keep this configuration in the local Codex config file, not in the repository. Do not commit machine-local paths.
@@ -74,7 +74,7 @@ This remote path was identified from repository metadata. The validation in this
 Run the local smoke test:
 
 ```powershell
-cd 'C:\Users\Immanuel Gabriel\Downloads\freshcontext-mcp'
+cd '<repo-root>'
 npm run smoke:stdio
 ```
 
@@ -99,8 +99,8 @@ Expected result: no output and exit code 0.
 
 ## Safety notes
 
-- Do not place secrets, API keys, registry tokens, npm tokens, GitHub tokens, or Cloudflare tokens in Codex MCP config.
-- Do not read, edit, print, or commit local token files such as `.env`, `.api-key.local.txt`, `.mcpregistry_*`, `.dev.vars`, or `.wrangler`.
+- Do not place secrets, credentials, registry tokens, npm tokens, GitHub tokens, or Cloudflare tokens in Codex MCP config.
+- Do not read, edit, print, or commit local token files, local environment files, registry credentials, Cloudflare local state, or Wrangler state.
 - Do not commit local Codex config or machine-specific paths.
 - Prefer the local stdio path for this compatibility check because it is verified by `npm run smoke:stdio`.
 - Do not claim Codex Cloud support unless it is separately tested and documented.

--- a/docs/DEPENDENCY_DILIGENCE.md
+++ b/docs/DEPENDENCY_DILIGENCE.md
@@ -1,6 +1,6 @@
 # FreshContext Dependency Diligence Notes
 
-This document records dependency and license diligence notes from the Trust L4/L5 cleanup. It is not legal advice and does not replace professional review for a serious transaction.
+This document records dependency and license diligence notes from the Trust L4/L5 cleanup. It is not legal advice and does not replace professional review for external review, distribution, or formal diligence.
 
 ## Current Audit Status
 
@@ -37,21 +37,21 @@ No GPL, AGPL, LGPL, MPL, EPL, CDDL, or similar copyleft licenses were reported i
 - Scanner result: `UNKNOWN`.
 - Path observed during L4: transitive through `apify` / Crawlee-related dependencies.
 - Diligence note: package metadata appears incomplete, but the installed package includes an MIT-style license file.
-- Action: keep as a diligence note and recheck before any transaction.
+- Action: keep as a diligence note and recheck before external diligence or distribution.
 
 `caniuse-lite`
 
 - Scanner result: `CC-BY-4.0`.
-- Diligence note: preserve and review attribution requirements before any sale, assignment, bundled distribution, or diligence package.
+- Diligence note: preserve and review attribution requirements before external diligence, bundled distribution, or a formal review package.
 
-## Before Sale Negotiation
+## Before External Diligence or Distribution
 
 - Rerun `npm audit --omit=dev`.
 - Rerun `npm audit`.
 - Rerun dependency license inventory.
 - Review scanner-unknown packages.
 - Review `caniuse-lite` attribution requirements.
-- Generate an SBOM if requested by a buyer, evaluator, or transaction advisor.
-- Review dependency and license posture with qualified counsel if a transaction becomes serious.
+- Generate an SBOM if requested by an evaluator, reviewer, or downstream distributor.
+- Review dependency and license posture with qualified counsel when external distribution or formal diligence requires it.
 
 Do not treat this document as a legal conclusion.

--- a/docs/RELEASE_INTEGRITY.md
+++ b/docs/RELEASE_INTEGRITY.md
@@ -21,11 +21,11 @@ This document describes release hardening practices for future FreshContext pack
 
 Confirm release artifacts do not include:
 
-- `.env` files.
-- Tokens or local API key files.
+- Local environment files.
+- Tokens or local credential files.
 - MCP registry local credential files.
 - Cloudflare local state.
-- `backup.sql` or local database snapshots.
+- Local database snapshots or SQL dumps.
 - Private sale, buyer, target, outreach, or diligence documents.
 - Private data-room folders.
 - Local logs.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,23 @@
   "bin": {
     "freshcontext-mcp": "dist/server.js"
   },
+  "files": [
+    ".env.example",
+    "dist/",
+    "docs/API_DESIGN.md",
+    "docs/CODEX_MCP_USAGE.md",
+    "docs/CORE_API.md",
+    "docs/DEPENDENCY_DILIGENCE.md",
+    "docs/HA_PRI_V2_DESIGN.md",
+    "docs/RELEASE_INTEGRITY.md",
+    "docs/SIGNAL_CONTRACT.md",
+    "docs/SOURCE_PROFILES.md",
+    "freshcontext.schema.json",
+    "NOTICE.md",
+    "SECURITY.md",
+    "server.json",
+    "TRADEMARKS.md"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/server.ts",


### PR DESCRIPTION
## Summary

Hardens the npm/package-facing surface before any publish or broader shareability push.

This is package/docs hygiene only. It does not change runtime behavior.

## Changes

* Adds an explicit npm `files` allowlist in `package.json`
* Updates `.npmignore` to explicitly exclude `tests/` and `examples/`
* Marks `npm run demo:*` workflows in `README.md` as source-checkout workflows
* Replaces personal Windows paths in `docs/CODEX_MCP_USAGE.md` with portable placeholders
* Replaces sale/negotiation language in `docs/DEPENDENCY_DILIGENCE.md` with neutral external diligence/distribution wording
* Generalizes local filename wording in `docs/RELEASE_INTEGRITY.md`

## Package policy

The package now ships runtime and selected public docs only:

* `dist/`
* `package.json`
* `README.md`
* `LICENSE`
* `server.json`
* selected public docs/notices/security/trademark/schema files

It no longer packs:

* `tests/`
* `examples/`
* `scripts/`
* `worker/`
* `demo/`
* `_archive/`
* session handoff docs
* private docs
* local backups
* local credential files

## npm pack result

`npm pack --dry-run --json` now reports:

* `entryCount`: 53, down from 79
* packed size: about 69 KB
* includes required runtime files: `dist/`, `package.json`, `README.md`, `LICENSE`, `server.json`
* focused pack audit found no packed path/content hits for:

  * personal Windows paths
  * `Before Sale Negotiation`
  * private data room wording
  * `backup.sql`
  * `.api-key.local`

## Trust scan

`npm run trust:scan:json` still has effective fail `0`.

Remaining summary:

* highest severity: `warn`
* effective warnings: 118
* effective info: 26
* raw findings: 144, down from 151

## Scope

Package/docs hygiene only.

No changes to:

* `src/`
* `worker/`
* tests
* adapters
* Core
* MCP behavior
* REST handler
* Trust Scanner rules

No deploy.
No npm publish.
No version bump.

## Validation

* `npm run build`
* `npm test` ? 154 passing
* `npm run demo:arxiv`
* `npm run demo:evaluate:file`
* `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
* `npx tsc --noEmit`
* `cd worker && npx tsc --noEmit`
* `npm run smoke:stdio`
* `npm run trust:scan:json`
* `npm pack --dry-run --json`
* `git diff --check`
* hidden-character scan ? no matches
