### PR TITLE
Pass 8-AD — Prepare 0.3.18 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 ## Roadmap
 
 - [x] FreshContext Specification v1.2 published (MIT, open standard)
-- [x] DAR engine with proprietary λ constants (v0.3.17)
+- [x] DAR engine with proprietary λ constants (v0.3.18)
 - [x] Ha-Pri v1 provenance signatures on stored signals
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`
@@ -330,7 +330,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
 - [x] Listed on official MCP Registry, Apify Store, npm
 - [ ] Ha-Pri v2 hardened canonical content hash verification
-- [x] GitHub Actions CI/CD — auto-publish on every push
+- [x] GitHub Actions release workflow — manual or `v*` tag-triggered npm publish path
 - [ ] Webhook triggers — push high-entropy signals on threshold
 - [ ] Dashboard — React frontend for the D1 intelligence pipeline
 - [ ] GKG upgrade for `extract_gdelt` — tone scores, goldstein scale, event codes
@@ -353,6 +353,7 @@ If you're building something FreshContext-compatible, open an issue and we'll ad
 - [TRADEMARKS.md](./TRADEMARKS.md)
 - [Dependency diligence notes](./docs/DEPENDENCY_DILIGENCE.md)
 - [Release integrity notes](./docs/RELEASE_INTEGRITY.md)
+- [Release notes](./docs/RELEASE_NOTES.md)
 
 ---
 

--- a/docs/CODEX_MCP_USAGE.md
+++ b/docs/CODEX_MCP_USAGE.md
@@ -83,8 +83,8 @@ Expected result:
 ```json
 {
   "ok": true,
-  "package_version": "0.3.17",
-  "server_version": "0.3.17",
+  "package_version": "0.3.18",
+  "server_version": "0.3.18",
   "tool_count": 21
 }
 ```

--- a/docs/IP_INVENTORY.md
+++ b/docs/IP_INVENTORY.md
@@ -141,7 +141,7 @@ Checklist:
 Known package presence:
 
 - npm package: `freshcontext-mcp`
-- current local package version: `0.3.17`
+- current local package version: `0.3.18`
 - MCP registry name in `package.json`: `io.github.PrinceGabriel-lgtm/freshcontext`
 - Ops Pulse npm package metadata: `freshcontext-ops-pulse`, local version `0.1.1`
 

--- a/docs/RELEASE_INTEGRITY.md
+++ b/docs/RELEASE_INTEGRITY.md
@@ -39,6 +39,8 @@ Confirm release artifacts do not include:
 
 ## Release Notes and Integrity Artifacts
 
+- Current prepared release notes: [`RELEASE_NOTES.md`](./RELEASE_NOTES.md).
+
 Future release hardening may include:
 
 - GitHub release notes for tagged releases.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,38 @@
+# FreshContext Release Notes
+
+## 0.3.18
+
+FreshContext 0.3.18 prepares the next npm package release without changing the deployed Worker or publishing automatically.
+
+### Core and Context Evaluation
+
+- Added the Core signal evaluation pipeline for normalized, freshness-ranked context results.
+- Added Source Profiles as Core metadata for source-aware policy vocabulary.
+- Added the Context Decision Helper so evaluated context can be interpreted as use, cite, verify, refresh, watch, background, or exclude.
+- Preserved the ranking boundary: `ranked.final_score` controls default ordering, while `utility.score` remains sidecar intelligence.
+
+### Bring Your Own Context
+
+- Added decision-first local demos for user-provided JSON source lists.
+- Added academic citation and jobs/opportunity sample inputs.
+- Added `npm run demo:evaluate:file` for local source-list evaluation from a cloned source checkout.
+
+### Adapter Path
+
+- Added adapter registry metadata for the 21 existing MCP tools.
+- Added additive arXiv signal extraction without changing the existing MCP `extract_arxiv` behavior.
+- Added an arXiv signal-to-decision proof using a static fixture, Core evaluation, and decision output.
+
+### Package and Release Hygiene
+
+- Hardened the npm package file allowlist.
+- Added script guards so repo-only scripts show a source-checkout notice in packed installs.
+- Isolated Apify/Crawlee from the normal MCP npm runtime package while preserving source-checkout Apify Actor support.
+- Confirmed fresh consumer installs no longer install Apify/Crawlee/file-type through the default MCP package path.
+
+### Boundaries
+
+- No npm publish in this preparation pass.
+- No git tag in this preparation pass.
+- No deployment in this preparation pass.
+- No Worker, REST handler, Core runtime, MCP tool schema, or adapter behavior changes are included in the version bump itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshcontext-mcp",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshcontext-mcp",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freshcontext-mcp",
   "mcpName": "io.github.PrinceGabriel-lgtm/freshcontext",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Real-time web intelligence for AI agents. 21 tools, no required API keys. Every result timestamped with a freshness score.",
   "keywords": [
     "mcp",
@@ -41,6 +41,7 @@
     "docs/DEPENDENCY_DILIGENCE.md",
     "docs/HA_PRI_V2_DESIGN.md",
     "docs/RELEASE_INTEGRITY.md",
+    "docs/RELEASE_NOTES.md",
     "docs/SIGNAL_CONTRACT.md",
     "docs/SOURCE_PROFILES.md",
     "freshcontext.schema.json",

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/PrinceGabriel-lgtm/freshcontext-mcp",
     "source": "github"
   },
-  "version": "0.3.17",
+  "version": "0.3.18",
   "website_url": "https://freshcontext-site.pages.dev",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "freshcontext-mcp",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,7 +23,7 @@ import { SecurityError, formatSecurityError } from "./security.js";
 
 const server = new McpServer({
   name: "freshcontext-mcp",
-  version: "0.3.17",
+  version: "0.3.18",
 });
 
 // ─── Tool: extract_github ────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary

Prepares the FreshContext MCP `0.3.18` release.

This is release preparation only. It does not publish npm, deploy, create a tag, or change runtime behavior beyond aligning version metadata.

## Changes

* Bumps package metadata to `0.3.18`
* Bumps `server.json` to `0.3.18`
* Updates MCP runtime `serverInfo.version` to `0.3.18`
* Fixes README publish workflow wording:

  * no longer claims auto-publish on every push
  * documents the actual manual / `v*` tag publish path
* Adds `docs/RELEASE_NOTES.md`
* Includes release notes in the npm package allowlist
* Updates release/package docs for the `0.3.18` package state

## Release notes cover

* Core decision helper
* Source Profiles
* bring-your-own-context demos
* adapter registry
* arXiv signal-to-decision proof
* package surface hardening
* package script guard
* Apify isolation from normal MCP runtime package
* clean fresh consumer install audit

## Validation

* `npm run build`
* `npm test` — 154 passed, 0 skipped
* `npm run demo:arxiv`
* `npm run demo:evaluate:file`
* `npm run demo:evaluate:file -- examples/sources.jobs.example.json`
* `npx tsc --noEmit`
* worker `npx tsc --noEmit`
* `npm run smoke:stdio` — 21 tools, `v0.3.18`
* `npm run trust:scan:json` — 0 effective fail findings
* `npm audit --omit=dev` — 0 vulnerabilities
* `npm audit` — 0 vulnerabilities
* `npm pack --dry-run --json`
* fresh packed install smoke:

  * `npm audit --omit=dev` clean
  * `dist/server.js` present
  * `dist/apify.js` absent
  * Apify/Crawlee/file-type absent
  * installed `npm start` returns 21 tools / `v0.3.18`
  * installed binary returns 21 tools / `v0.3.18`
  * installed `npm test` prints the friendly source-checkout guard notice
* Ops Pulse:

  * clean status
  * `npm run check` pass
  * `npm run build` pass

## Scope

No npm publish.
No deploy.
No git tag.
No Worker deploy.
No package registry update.

## Note

`docs/FRESHCONTEXT_MATH_SPINE_REVIEW.md` still references `0.3.17` intentionally because it is a dated historical review artifact, not current release metadata.
