### PR TITLE
FreshContext Trust Scanner Phase 2B - multi-repo trust surface grouping

### DIFF
--- a/scripts/trust-scan.mjs
+++ b/scripts/trust-scan.mjs
@@ -127,27 +127,29 @@ async function main() {
   const cwd = process.cwd();
   const rulesPath = path.join(cwd, "config", "trust-scan-rules.json");
   const allowlistPath = path.join(cwd, "config", "trust-scan-allowlist.json");
-  const [rules, allowlist, packageMetadata] = await Promise.all([
+  const [rules, allowlist] = await Promise.all([
     loadRules(rulesPath),
-    loadAllowlist(allowlistPath),
-    loadPackageMetadata(cwd)
+    loadAllowlist(allowlistPath)
   ]);
   const compiledRules = compileRules(rules);
   validateAllowlistRuleIds(allowlist, compiledRules);
-  const scanState = createScanState({
-    cwd,
-    rules: compiledRules,
-    allowlist,
-    packageMetadata
-  });
+  const projectStates = [];
 
   for (const selectedPath of args.paths) {
     const absolutePath = path.resolve(cwd, selectedPath);
+    const scanState = await createProjectScanState({
+      cwd,
+      selectedPath,
+      absolutePath,
+      rules: compiledRules,
+      allowlist
+    });
     await scanSelectedPath(absolutePath, scanState);
+    finalizeRepoMap(scanState);
+    projectStates.push(scanState);
   }
 
-  finalizeRepoMap(scanState);
-  const report = generateReport(scanState, { includeRepoMap: args.repoMap });
+  const report = generateReport(projectStates, { includeRepoMap: args.repoMap });
   writeReport(report, args.output, { showAllowed: args.showAllowed, showRepoMap: args.repoMap });
 
   if (shouldFail(report.summary, args.failOn)) {
@@ -439,9 +441,42 @@ function compileRules(rules) {
   });
 }
 
-function createScanState({ cwd, rules, allowlist, packageMetadata }) {
+async function createProjectScanState({ cwd, selectedPath, absolutePath, rules, allowlist }) {
+  const projectRoot = await resolveProjectRoot(absolutePath);
+  const packageMetadata = await loadPackageMetadata(projectRoot);
+
+  return createScanState({
+    cwd: projectRoot,
+    baseCwd: cwd,
+    projectName: projectNameFromPath(projectRoot, absolutePath),
+    projectRoot,
+    selectedPath,
+    rules,
+    allowlist,
+    packageMetadata
+  });
+}
+
+async function resolveProjectRoot(absolutePath) {
+  try {
+    const stat = await fs.lstat(absolutePath);
+    return stat.isDirectory() ? absolutePath : path.dirname(absolutePath);
+  } catch {
+    return path.dirname(absolutePath);
+  }
+}
+
+function projectNameFromPath(projectRoot, absolutePath) {
+  return path.basename(projectRoot) || path.basename(absolutePath) || ".";
+}
+
+function createScanState({ cwd, baseCwd, projectName, projectRoot, selectedPath, rules, allowlist, packageMetadata }) {
   return {
     cwd,
+    baseCwd,
+    projectName,
+    projectRoot,
+    selectedPath,
     rules,
     allowlist,
     packageMetadata,
@@ -1114,24 +1149,75 @@ function createRepoMapFinding({ ruleId, severity, message, recommendation }) {
   };
 }
 
-function generateReport(state, options = {}) {
-  const sortedFindings = sortFindings(state.findings);
-  const summary = generateSummaryStats(sortedFindings, state.stats);
+function generateReport(states, options = {}) {
+  const projectStates = Array.isArray(states) ? states : [states];
+  const projects = projectStates.map((state) => generateProjectReport(state, options));
+  const sortedFindings = sortFindings(projects.flatMap((project) => project.findings));
+  const summary = generateSummaryStats(sortedFindings, aggregateStats(projectStates), {
+    projectsScanned: projects.length,
+    groupProjectPaths: projects.length > 1
+  });
   const report = {
     tool: TOOL_NAME,
+    package: projects[0]?.package ?? null,
+    summary,
+    projects,
+    findings: sortedFindings
+  };
+
+  if (options.includeRepoMap && projects.length === 1) {
+    report.repoMap = projects[0].repoMap;
+  }
+
+  return report;
+}
+
+function generateProjectReport(state, options = {}) {
+  const sortedFindings = sortFindings(state.findings.map((finding) => annotateProjectFinding(finding, state)));
+  const summary = generateSummaryStats(sortedFindings, state.stats, { projectsScanned: 1 });
+  const project = {
+    name: state.projectName,
+    root: normalizePath(path.resolve(state.projectRoot)),
+    selectedPath: state.selectedPath,
     package: state.packageMetadata,
     summary,
     findings: sortedFindings
   };
 
   if (options.includeRepoMap) {
-    report.repoMap = state.repoMap;
+    project.repoMap = state.repoMap;
   }
 
-  return report;
+  return project;
 }
 
-function generateSummaryStats(findings, stats) {
+function annotateProjectFinding(finding, state) {
+  const projectPath = finding.path === "." ? state.projectName : `${state.projectName}/${finding.path}`;
+  return {
+    project: state.projectName,
+    projectRoot: normalizePath(path.resolve(state.projectRoot)),
+    projectPath: normalizePath(projectPath),
+    ...finding
+  };
+}
+
+function aggregateStats(states) {
+  return states.reduce((stats, state) => ({
+    scannedFiles: stats.scannedFiles + state.stats.scannedFiles,
+    skippedFiles: stats.skippedFiles + state.stats.skippedFiles,
+    skippedDirectories: stats.skippedDirectories + state.stats.skippedDirectories,
+    visitedDirectories: stats.visitedDirectories + state.stats.visitedDirectories,
+    scanErrors: stats.scanErrors + state.stats.scanErrors
+  }), {
+    scannedFiles: 0,
+    skippedFiles: 0,
+    skippedDirectories: 0,
+    visitedDirectories: 0,
+    scanErrors: 0
+  });
+}
+
+function generateSummaryStats(findings, stats, options = {}) {
   const allowedFindings = findings.filter((finding) => finding.allowed).length;
   const unallowedFindings = findings.length - allowedFindings;
   const highestSeverity = findings
@@ -1152,13 +1238,14 @@ function generateSummaryStats(findings, stats) {
     allowedFindings,
     unallowedFindings,
     highestSeverity,
+    projectsScanned: options.projectsScanned,
     scanErrors: stats.scanErrors,
     findingsBySeverity: countBy(findings, "severity", ["fail", "warn", "info"]),
     findingsByEffectiveSeverity: countBy(findings, "effectiveSeverity", ["fail", "warn", "info"]),
     findingsByCategory: countBy(findings, "category"),
     findingsByRule: countBy(findings, "ruleId"),
     findingsByFileCategory: countBy(findings, "fileCategory"),
-    topPaths: topCounts(findings, "path", 10),
+    topPaths: topCounts(findings, options.groupProjectPaths ? "projectPath" : "path", 10),
     downgradedFindings: downgradedFindings.length,
     topDowngradedRules: topCounts(downgradedFindings, "ruleId", 10)
   };
@@ -1174,6 +1261,11 @@ function sortFindings(findings) {
     const rawSeverityDiff = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
     if (rawSeverityDiff !== 0) {
       return rawSeverityDiff;
+    }
+
+    const projectDiff = (a.project ?? "").localeCompare(b.project ?? "");
+    if (projectDiff !== 0) {
+      return projectDiff;
     }
 
     const pathDiff = a.path.localeCompare(b.path);
@@ -1240,6 +1332,7 @@ function writeReport(report, outputMode, options = {}) {
 
 function formatHuman(report, options = {}) {
   const visibleFindings = filterVisibleFindings(report.findings, options);
+  const showProjectBreakdown = Array.isArray(report.projects) && report.projects.length > 1;
   const lines = [
     TOOL_NAME,
     "",
@@ -1249,6 +1342,11 @@ function formatHuman(report, options = {}) {
 
   if (options.showRepoMap && report.repoMap) {
     lines.push(...formatHumanRepoMap(report.repoMap));
+    lines.push("");
+  }
+
+  if (showProjectBreakdown) {
+    lines.push(...formatHumanProjects(report.projects, options));
     lines.push("");
   }
 
@@ -1273,8 +1371,12 @@ function formatHuman(report, options = {}) {
   for (const finding of visibleFindings) {
     const allowedLabel = finding.allowed ? " ALLOWED" : "";
     const rawLabel = finding.severity === finding.effectiveSeverity ? "" : ` (raw ${finding.severity.toUpperCase()})`;
-    lines.push(`${finding.effectiveSeverity.toUpperCase()}${rawLabel}${allowedLabel} ${finding.ruleId} ${finding.path}:${finding.line}`);
+    const findingPath = finding.project ? `${finding.project}/${finding.path}` : finding.path;
+    lines.push(`${finding.effectiveSeverity.toUpperCase()}${rawLabel}${allowedLabel} ${finding.ruleId} ${findingPath}:${finding.line}`);
     lines.push(finding.message);
+    if (finding.project) {
+      lines.push(`Project: ${finding.project}`);
+    }
     lines.push(`File category: ${finding.fileCategory}`);
     lines.push(`Severity reason: ${finding.severityReason}`);
     if (finding.match) {
@@ -1293,9 +1395,9 @@ function formatHuman(report, options = {}) {
 function formatMarkdown(report, options = {}) {
   const visibleFindings = filterVisibleFindings(report.findings, options);
   const lines = [
-    `# ${TOOL_NAME}`,
+    `# ${TOOL_NAME} Report`,
     "",
-    "## Summary",
+    "## Global Summary",
     "",
     ...formatSummaryLines(report.summary).map((line) => `- ${line}`),
     ""
@@ -1303,6 +1405,11 @@ function formatMarkdown(report, options = {}) {
 
   if (options.showRepoMap && report.repoMap) {
     lines.push(...formatMarkdownRepoMap(report.repoMap));
+    lines.push("");
+  }
+
+  if (Array.isArray(report.projects) && report.projects.length > 0) {
+    lines.push(...formatMarkdownProjects(report.projects, options));
     lines.push("");
   }
 
@@ -1345,6 +1452,9 @@ function formatMarkdown(report, options = {}) {
     const rawLabel = finding.severity === finding.effectiveSeverity ? "" : ` (raw ${finding.severity.toUpperCase()})`;
     lines.push(`### ${finding.effectiveSeverity.toUpperCase()}${rawLabel}${allowedLabel}: ${finding.ruleId}`);
     lines.push("");
+    if (finding.project) {
+      lines.push(`- Project: \`${finding.project}\``);
+    }
     lines.push(`- Path: \`${finding.path}:${finding.line}\``);
     lines.push(`- File category: \`${finding.fileCategory}\``);
     lines.push(`- Severity reason: ${finding.severityReason}`);
@@ -1361,7 +1471,7 @@ function formatMarkdown(report, options = {}) {
 }
 
 function formatSummaryLines(summary) {
-  return [
+  const lines = [
     `Scanned files: ${summary.scannedFiles}`,
     `Skipped files: ${summary.skippedFiles}`,
     `Findings: ${summary.findings}`,
@@ -1370,6 +1480,98 @@ function formatSummaryLines(summary) {
     `Highest severity: ${summary.highestSeverity}`,
     `Downgraded findings: ${summary.downgradedFindings}`
   ];
+
+  if (summary.projectsScanned !== undefined) {
+    lines.splice(2, 0, `Projects scanned: ${summary.projectsScanned}`);
+  }
+
+  return lines;
+}
+
+function formatHumanProjects(projects, options = {}) {
+  const lines = ["Projects:"];
+
+  for (const project of projects) {
+    const severity = severityCountMap(project.summary);
+    lines.push("");
+    lines.push(`${project.name}`);
+    lines.push(`  root: ${project.root}`);
+    lines.push(`  scanned: ${project.summary.scannedFiles}`);
+    lines.push(`  skipped: ${project.summary.skippedFiles}`);
+    lines.push(`  findings: ${project.summary.findings}`);
+    lines.push(`  allowed: ${project.summary.allowedFindings}`);
+    lines.push(`  unallowed: ${project.summary.unallowedFindings}`);
+    lines.push(`  fail: ${severity.fail} warn: ${severity.warn} info: ${severity.info}`);
+    lines.push(`  highest: ${project.summary.highestSeverity}`);
+    lines.push(`  top rules: ${formatInlineCounts(project.summary.findingsByRule, 3)}`);
+    lines.push(`  top categories: ${formatInlineCounts(project.summary.findingsByCategory, 3)}`);
+    lines.push(`  top paths: ${formatInlineCounts(project.summary.topPaths, 3)}`);
+
+    if (options.showRepoMap && project.repoMap) {
+      lines.push(`  repo map: ${formatInlineRepoMap(project.repoMap)}`);
+    }
+  }
+
+  return lines;
+}
+
+function formatMarkdownProjects(projects, options = {}) {
+  const lines = ["## Projects", ""];
+
+  for (const project of projects) {
+    const severity = severityCountMap(project.summary);
+    lines.push(`### ${project.name}`);
+    lines.push("");
+    lines.push(`- Root: \`${project.root}\``);
+    lines.push(`- Scanned files: ${project.summary.scannedFiles}`);
+    lines.push(`- Skipped files: ${project.summary.skippedFiles}`);
+    lines.push(`- Findings: ${project.summary.findings}`);
+    lines.push(`- Allowed findings: ${project.summary.allowedFindings}`);
+    lines.push(`- Unallowed findings: ${project.summary.unallowedFindings}`);
+    lines.push(`- Effective severity: fail ${severity.fail}, warn ${severity.warn}, info ${severity.info}`);
+    lines.push(`- Highest severity: ${project.summary.highestSeverity}`);
+    lines.push(`- Top rules: ${formatInlineCounts(project.summary.findingsByRule, 5)}`);
+    lines.push(`- Top categories: ${formatInlineCounts(project.summary.findingsByCategory, 5)}`);
+    lines.push(`- Top paths: ${formatInlineCounts(project.summary.topPaths, 5)}`);
+
+    if (options.showRepoMap && project.repoMap) {
+      lines.push(`- Repo map: ${formatInlineRepoMap(project.repoMap)}`);
+    }
+
+    lines.push("");
+  }
+
+  return lines;
+}
+
+function severityCountMap(summary) {
+  const counts = Object.fromEntries(summary.findingsByEffectiveSeverity.map((entry) => [entry.name, entry.count]));
+  return {
+    fail: counts.fail ?? 0,
+    warn: counts.warn ?? 0,
+    info: counts.info ?? 0
+  };
+}
+
+function formatInlineCounts(entries, limit) {
+  const visible = entries.filter((entry) => entry.count > 0).slice(0, limit);
+  if (visible.length === 0) {
+    return "none";
+  }
+
+  return visible.map((entry) => `${entry.name} ${entry.count}`).join(", ");
+}
+
+function formatInlineRepoMap(repoMap) {
+  return [
+    `public docs ${repoMap.publicDocs.length}`,
+    `private/archive docs ${repoMap.privateOrArchiveDocs.length}`,
+    `source ${repoMap.sourceFiles.length}`,
+    `tests ${repoMap.testFiles.length}`,
+    `config ${repoMap.configFiles.length}`,
+    `package-boundary ${repoMap.packageBoundaryFiles.length}`,
+    `unknown ${repoMap.unknownFiles.length}`
+  ].join(", ");
 }
 
 function formatHumanRepoMap(repoMap) {

--- a/tests/trustScan.test.mjs
+++ b/tests/trustScan.test.mjs
@@ -236,6 +236,74 @@ test("repo-map project warnings are warn-level and fail gate still uses effectiv
   }
 });
 
+test("multiple path scans include project grouping in JSON", async () => {
+  const fixture = await createFixture();
+  try {
+    const alpha = path.join(fixture, "alpha");
+    const beta = path.join(fixture, "beta");
+    await mkdir(alpha, { recursive: true });
+    await mkdir(path.join(beta, "_archive"), { recursive: true });
+
+    const rawSecret = ["sk", "multiRepoSecret12345"].join("-");
+    await writeFile(path.join(alpha, "README.md"), `Current docs mention ${staleToolCountClaim} and ${rawSecret}.\n`, "utf8");
+    await writeFile(path.join(beta, "_archive", "notes.md"), `Historical ${staleToolCountClaim} note.\n`, "utf8");
+
+    const result = runScanner(fixture, ["--path", "alpha", "--path", "beta", "--repo-map", "--json"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.includes(rawSecret), false);
+
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.summary.projectsScanned, 2);
+    assert.equal(report.projects.length, 2);
+    assert.deepEqual(report.projects.map((project) => project.name), ["alpha", "beta"]);
+    assert.equal(report.findings.length > 0, true);
+
+    const alphaProject = report.projects.find((project) => project.name === "alpha");
+    const betaProject = report.projects.find((project) => project.name === "beta");
+    assert.equal(alphaProject.repoMap.hasReadme, true);
+    assert.equal(betaProject.repoMap.privateOrArchiveDocs.includes("_archive/notes.md"), true);
+
+    const secretFinding = report.findings.find((finding) => finding.ruleId === "secret-openai-key-shape");
+    assert.equal(secretFinding.project, "alpha");
+    assert.equal(secretFinding.match, "sk-[REDACTED]");
+    assert.equal(report.findings.some((finding) => finding.project === "beta" && finding.ruleId === "stale-20-tools"), true);
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
+test("multi-project Markdown and fail gate remain grouped and redacted", async () => {
+  const fixture = await createFixture();
+  try {
+    const alpha = path.join(fixture, "alpha");
+    const beta = path.join(fixture, "beta");
+    await mkdir(alpha, { recursive: true });
+    await mkdir(beta, { recursive: true });
+
+    const rawSecret = ["sk", "failGateSecret12345"].join("-");
+    await writeFile(path.join(alpha, "README.md"), "Clean docs.\n", "utf8");
+    await writeFile(path.join(beta, "README.md"), `Token ${rawSecret}\n`, "utf8");
+
+    const markdown = runScanner(fixture, ["--path", "alpha", "--path", "beta", "--repo-map", "--markdown"]);
+    assert.equal(markdown.status, 0, markdown.stderr);
+    assert.match(markdown.stdout, /## Projects/u);
+    assert.match(markdown.stdout, /### alpha/u);
+    assert.match(markdown.stdout, /### beta/u);
+    assert.equal(markdown.stdout.includes(rawSecret), false);
+
+    const gated = runScanner(fixture, ["--path", "alpha", "--path", "beta", "--fail-on", "fail", "--json"]);
+    assert.equal(gated.status, 1);
+    assert.equal(gated.stdout.includes(rawSecret), false);
+
+    const report = JSON.parse(gated.stdout);
+    assert.equal(report.summary.highestSeverity, "fail");
+    assert.equal(report.projects.find((project) => project.name === "beta").summary.highestSeverity, "fail");
+    assert.equal(report.projects.find((project) => project.name === "alpha").summary.highestSeverity, "warn");
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 async function createFixture({ rules = baseRules, allowlist = { allow: [] }, withPackageJson = false } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), "trust-scan-"));
   await mkdir(path.join(root, "config"), { recursive: true });


### PR DESCRIPTION
﻿## Summary

Adds Phase 2B multi-repo trust surface grouping to the FreshContext Trust Scanner.

The scanner already supported multiple `--path` values. This PR makes multi-path scans easier to read and consume by grouping findings, summaries, and repo-map data by project/root while preserving the existing top-level report shape.

## What changed

- Adds per-project grouping for multi-path scans.
- Adds top-level JSON `projects[]`.
- Preserves top-level `findings` for compatibility with existing JSON consumers.
- Preserves single-project top-level `repoMap` behavior when `--repo-map` is used.
- Adds project breakdowns to human and Markdown output.
- Adds project labels and project roots to findings.
- Adds tests for multi-path JSON, Markdown project sections, secret redaction, and cross-project fail-gate behavior.

## Current validation

```text
node scripts/trust-scan.mjs --path . --fail-on fail  -> passed
npm run build                                        -> passed
npm test                                             -> passed, 156/156
npm run smoke:stdio                                  -> passed, 21 tools
```

## Multi-repo scan shape

The new report can group a FreshContext trust surface scan across paths like:

```text
freshcontext-mcp
freshcontext-site
freshcontext-profile
freshcontext-ops-pulse
freshcontext-hn-feed
```

Current observed grouped result during local validation:

```text
freshcontext-mcp        fail 0  warn 118  info 26   findings 144
freshcontext-site       fail 0  warn 2    info 5    findings 7
freshcontext-profile    fail 0  warn 1    info 1    findings 2
freshcontext-ops-pulse  fail 1  warn 21   info 13   findings 35
freshcontext-hn-feed    fail 3  warn 97   info 25   findings 125
```

Known cross-surface findings are grouped and redacted correctly. This PR intentionally does not fix those findings.

## Boundaries

This PR does not:

- implement Phase 3/package gate behavior
- modify FreshContext Core behavior
- modify Worker runtime behavior
- modify adapters
- modify other FreshContext repos
- fix cross-surface findings
- deploy anything
- publish anything
- force-add ignored `docs/TRUST_ROADMAP.md`
