### PR TITLE
Align cloud Worker metadata with 0.3.18

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshcontext-mcp-worker",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshcontext-mcp-worker",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.0.4",
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freshcontext-mcp-worker",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "private": true,
   "scripts": {
     "dev": "wrangler dev",

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -12,7 +12,7 @@ import {
   stamp,
 } from "./freshcontextEnvelope.js";
 
-const SERVICE_VERSION = "0.3.17";
+const SERVICE_VERSION = "0.3.18";
 const SERVICE_UA = `freshcontext-mcp/${SERVICE_VERSION} (https://github.com/PrinceGabriel-lgtm/freshcontext-mcp)`;
 
 // ─── Types ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Aligns the Cloudflare Worker package/runtime metadata with the published FreshContext MCP 0.3.18 release.

## Changes

- Updates worker package metadata to 0.3.18
- Updates Worker SERVICE_VERSION to 0.3.18
- Keeps Worker behavior unchanged

## Validation

- npm run build
- npm test: 172 passed, 0 skipped
- Worker typecheck: npx tsc --noEmit
- npm run smoke:stdio: 21 tools, v0.3.18
- npm run trust:scan:json: 0 effective fail findings
- wrangler deploy --dry-run
- wrangler deploy
- Cloud root endpoint now reports version 0.3.18

## Scope

No Core changes.
No adapter changes.
No MCP tool/schema changes.
No REST changes.
No site changes.
No npm publish.
