### PR TITLE
Pass 10 — Buyer-safe packaging and future lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,12 +351,14 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 - [x] Named reference adapters across intelligence, competitive research, market data, and composites
 - [x] Core-backed envelope generation shared by npm/MCP and the Cloudflare Worker
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
-- [x] Listed on official MCP Registry, Apify Store, npm
+- [x] Published on npm and listed for MCP usage; Apify/feed assets are separated from the normal MCP runtime package
 - [ ] Ha-Pri v2 hardened canonical content hash verification
 - [x] GitHub Actions release workflow — manual or `v*` tag-triggered npm publish path
 - [ ] Webhook triggers — push high-entropy signals on threshold
 - [ ] Dashboard — React frontend for the D1 intelligence pipeline
 - [ ] GKG upgrade for `extract_gdelt` — tone scores, goldstein scale, event codes
+
+Future work is organized in [FreshContext Future Lanes](./docs/FUTURE_LANES.md). Roadmap items are not live product claims until implemented and validated.
 
 ---
 
@@ -391,4 +393,4 @@ MIT
 
 ---
 
-**Also on:** [Apify Store](https://apify.com/prince_gabriel/freshcontext-mcp) · [MCP Registry](https://registry.modelcontextprotocol.io) · [npm](https://www.npmjs.com/package/freshcontext-mcp)
+**Also on:** [MCP Registry](https://registry.modelcontextprotocol.io) · [npm](https://www.npmjs.com/package/freshcontext-mcp)

--- a/docs/FUTURE_LANES.md
+++ b/docs/FUTURE_LANES.md
@@ -1,0 +1,170 @@
+# FreshContext Future Lanes
+
+This document keeps future FreshContext work organized without turning roadmap ideas into public claims.
+
+FreshContext is live today as an integrated MCP/Core package. Future work should stay in lanes, start with audits, and avoid feature sprawl.
+
+## Current Live Boundary
+
+Live today:
+
+- npm package: `freshcontext-mcp@0.3.18`
+- MCP stdio server
+- 21 read-only reference adapters
+- Core signal evaluation
+- Source Profiles
+- Decision Helper
+- adapter registry metadata
+- arXiv signal-to-decision proof
+- bring-your-own-context local demos
+- Trust Scanner release gate
+
+Not live today:
+
+- Operator / `retrieve(...)`
+- browser crawling
+- automatic local file, folder, or PDF scanning
+- hosted dashboard or billing
+- hard Ha-Pri v2 production enforcement
+- standalone Core SDK package
+- full adapter ingestion
+
+## Lane 1: Client Setup Reliability
+
+Goal:
+
+```text
+Make Claude, Codex, and MCP-compatible clients connect reliably to the published package.
+```
+
+Start with setup guide audits, Claude Desktop local/global package paths, Codex local MCP config paths, stale global package fixes, and smoke command expectations.
+
+Do not claim ChatGPT/OpenAI connector compatibility until a separate compatibility audit is done.
+
+## Lane 2: Generic Context Evaluation
+
+Goal:
+
+```text
+Let any caller provide candidate context and get decision-ready output.
+```
+
+Possible MCP tool:
+
+```text
+evaluate_context
+```
+
+Hard boundary:
+
+```text
+No fetching, crawling, browsing, folder reading, or retrieval orchestration.
+Only evaluate caller-provided candidate context.
+```
+
+This lane should start with an audit before implementation. Tool count changes only if the tool lands.
+
+## Lane 3: Multi-Agent Context Handoff Proof
+
+Goal:
+
+```text
+Show FreshContext as an independent context judgment layer between agents.
+```
+
+Proof shape:
+
+```text
+agent A produces candidate context
+-> FreshContext evaluates it
+-> agent B receives decision-ready context
+```
+
+Do not build a full multi-agent framework. Prove the handoff boundary.
+
+## Lane 4: Core SDK Extraction Audit
+
+Goal:
+
+```text
+Decide whether Core should become a standalone package.
+```
+
+Audit current Core exports, dependency boundaries, package shape, browser/node compatibility, public API stability, and what remains MCP-only.
+
+No extraction without a compatibility plan.
+
+## Lane 5: Local/User Data Intake Audit
+
+Goal:
+
+```text
+Explore student, research, and local-PC workflows safely.
+```
+
+Candidate sources include notes, PDFs, local JSON/CSV, citation exports, and database rows.
+
+Hard boundary:
+
+```text
+Consent-first design. No automatic folder scanning or background file reading.
+```
+
+## Lane 6: Decision Layer Upgrade
+
+Goal:
+
+```text
+Make decisions more useful without silently changing ranking.
+```
+
+Possible inputs include context utility, control signal, future context signal, confidence tiers, and source-profile-specific thresholds.
+
+Do not make `utility.score` affect ranking by default without a dedicated ranking policy pass.
+
+## Lane 7: Ha-Pri v2 Production Path
+
+Goal:
+
+```text
+Turn Ha-Pri v2 from pure Core helper/design into production enforcement where appropriate.
+```
+
+Audit canonical content material, storage path, verification timing, failure mode, D1/Worker compatibility, and migration plan.
+
+Do not claim hard tamper enforcement until the read/write path exists.
+
+## Lane 8: GDELT GKG / Richer Source Intelligence
+
+Goal:
+
+```text
+Upgrade GDELT intelligence with richer global knowledge graph signals.
+```
+
+Possible fields include tone, Goldstein scale, event codes, actor geography, theme density, and source timeline.
+
+Do not mix this with generic context evaluation or local intake.
+
+## Lane 9: Operator / Retrieve Orchestration
+
+Goal:
+
+```text
+Coordinate retrieval only after the decision layer and adapter boundaries are mature.
+```
+
+Operator may later select adapters, call retrievers, refresh stale sources, and package best context.
+
+Not now. Operator is a later workflow layer over Core and adapters.
+
+## Operating Rule
+
+Every lane starts with:
+
+```text
+audit -> small patch -> validation -> stop
+```
+
+Do not combine lanes because the architecture is tempting.
+

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## 0.3.18
 
-FreshContext 0.3.18 prepares the next npm package release without changing the deployed Worker or publishing automatically.
+FreshContext 0.3.18 is the current published npm package release. It makes the MCP/Core package easier to install, validate, and explain without changing the deployed Worker runtime.
 
 ### Core and Context Evaluation
 
@@ -32,7 +32,7 @@ FreshContext 0.3.18 prepares the next npm package release without changing the d
 
 ### Boundaries
 
-- No npm publish in this preparation pass.
-- No git tag in this preparation pass.
-- No deployment in this preparation pass.
-- No Worker, REST handler, Core runtime, MCP tool schema, or adapter behavior changes are included in the version bump itself.
+- No Worker deploy is part of the npm package release.
+- No hosted dashboard, billing system, Operator mode, browser crawling, or local file scanning is included.
+- No Worker, REST handler, MCP tool schema, or existing adapter behavior changes are included in the package release itself.
+- Future work is tracked in [`FUTURE_LANES.md`](./FUTURE_LANES.md).

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "docs/CODEX_MCP_USAGE.md",
     "docs/CORE_API.md",
     "docs/DEPENDENCY_DILIGENCE.md",
+    "docs/FUTURE_LANES.md",
     "docs/HA_PRI_V2_DESIGN.md",
     "docs/RELEASE_INTEGRITY.md",
     "docs/RELEASE_NOTES.md",


### PR DESCRIPTION
## Summary

Organizes FreshContext's public future work and buyer-safe package framing without adding new runtime features.

## Changes

- Adds `docs/FUTURE_LANES.md`
- Includes `docs/FUTURE_LANES.md` in the npm package allowlist
- Updates `docs/RELEASE_NOTES.md` so `0.3.18` is described as the current published npm package release
- Removes stale public Apify Store listing language from `README.md`
- Adds a README pointer to future lanes so roadmap work is organized without being claimed as live

## Scope

Docs/package-surface hygiene only.

No changes to:

- Core behavior
- MCP runtime behavior
- adapters
- Worker
- REST handler
- demos
- version
- npm publish
- deploy

## Validation

- `git diff --check` clean except normal CRLF warnings
- hidden-character scan: no output
- `npm run smoke:stdio` — 21 tools / v0.3.18
- `npm run trust:gate` — effective fail findings: 0
- `npm pack --dry-run --json` — 55 files, includes `docs/FUTURE_LANES.md`
- `npm run build`
- `npm test` — 172 passed, 0 skipped

## Private packaging note

Buyer-shareable and private-control files were created outside the public repo in the local private data room. They are intentionally not part of this PR or npm package.