### PR TITLE
Pass 11-B/C — Interface reframe and evaluate_context

### DIFF
--- a/FRESHCONTEXT_SPEC.md
+++ b/FRESHCONTEXT_SPEC.md
@@ -248,7 +248,7 @@ Claude Desktop is a supported MCP client, but FreshContext Core is not Claude-de
 
 The canonical reference implementation of this specification is:
 
-**freshcontext-mcp@0.3.17** — an MCP server with 21 read-only MCP tools / reference adapters covering:
+**freshcontext-mcp@0.3.18** — an MCP server with `evaluate_context` for caller-provided candidate context plus 21 read-only reference adapters covering:
 
 **Intelligence:** GitHub, Hacker News, Google Scholar, arXiv, Reddit
 
@@ -256,7 +256,7 @@ The canonical reference implementation of this specification is:
 
 **Market data:** Stooq quote data (up to 5 tickers), job listings (Remotive, RemoteOK, HN Hiring)
 
-**Unique — not available in any other MCP server:**
+**Official, regulatory, and procurement sources:**
 - `extract_changelog` — release history from any repo, npm package, or website
 - `extract_govcontracts` — US federal contract awards (USASpending.gov)
 - `extract_sec_filings` — SEC 8-K material event disclosures (EDGAR)
@@ -282,13 +282,13 @@ The canonical reference implementation of this specification is:
 - Added Core-backed envelope/scoring implementation status.
 - Added optional context-conditioned scoring language without changing the envelope contract.
 - Clarified MCP as one interface over the FreshContext methodology.
-- Updated reference implementation language for freshcontext-mcp@0.3.17 and 21 read-only tools/reference adapters.
+- Updated reference implementation language for freshcontext-mcp@0.3.18, `evaluate_context`, and 21 read-only reference adapters.
 
 ### Version 1.1 — April 2026
 - Added Composite Adapters section
 - Added domain-specific decay rate table with recommended values
 - Added Compatibility Levels table (compatible / aware / scored)
-- Updated reference implementation to 21 tools
+- Updated reference implementation to 21 reference adapter tools
 - Added `extract_gdelt`, `extract_gebiz`, `extract_sec_filings` to high-confidence examples
 - Added Apify Store and MCP Registry to reference implementation listings
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -52,7 +52,7 @@ This D1 cron ledger is one implementation layer and future Store direction. It i
 
 FreshContext currently has:
 
-- A reference MCP implementation with 21 read-only MCP tools / reference adapters
+- A reference MCP implementation with `evaluate_context` and 21 read-only reference adapters
 - Separate feed products such as Fresh HN Feed and Fresh Jobs Feed
 - A Store/Ledger methodology for systems that collect recurring signals over time
 
@@ -356,7 +356,7 @@ For technical integrators, auditors, and future platform partners:
 
 5. **The Store / Ledger design** — support for recurring watched queries, historical signal accumulation, D1-backed storage, and time-series auditability.
 
-6. **The Reference Implementation** — `freshcontext-mcp@0.3.17`, 21 read-only MCP tools / reference adapters, listed on the official MCP Registry and npm. Deployed globally on Cloudflare's edge infrastructure.
+6. **The Reference Implementation** — `freshcontext-mcp@0.3.18`, the `evaluate_context` MCP interface, and 21 read-only reference adapters, listed on the official MCP Registry and npm. Deployed globally on Cloudflare's edge infrastructure.
 
 ---
 
@@ -365,7 +365,7 @@ For technical integrators, auditors, and future platform partners:
 ### Version 1.2 — May 2026
 - Clarified Core methodology vs Store/Ledger methodology.
 - Preserved DAR as the mathematical scoring backbone.
-- Updated reference implementation language for 21 MCP tools/reference adapters.
+- Updated reference implementation language for `evaluate_context` plus 21 MCP reference adapters.
 - Reframed source decay constants as reference defaults/calibration values.
 - Added failure-honesty methodology.
 - Added context-conditioned utility as a Core scoring primitive.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ That's not hallucination. That's correct summarization of corrupted retrieval.
 
 ## The layer
 
-FreshContext is a **temporal correction layer for retrieval systems**. One math correction applied before context reaches the LLM:
+FreshContext is **context integrity infrastructure for AI agents and retrieval systems**. It sits between retrieval and reasoning:
+
+```text
+candidate context
+  -> FreshContext Core
+  -> decision-ready context
+  -> model / agent / app
+```
+
+FreshContext evaluates freshness, source profile, confidence, utility, provenance material, and failure honesty before context reaches the LLM. The temporal core uses Decay-Adjusted Relevancy:
 
 ```
 R_t = R_0 · e^(−λt)
@@ -41,7 +50,7 @@ R_t = R_0 · e^(−λt)
 - `t` — hours elapsed since publication
 - `R_t` — decay-adjusted relevancy at query time
 
-That's the whole fix. No model swap. No re-embedding. No re-indexing. The layer drops onto whatever retrieval pipeline you already have.
+That's the core correction. No model swap. No re-embedding. No re-indexing. The layer drops onto whatever retrieval pipeline you already have.
 
 **The layer is the product.** The named adapters shipped with this repo demonstrate compatibility across different source classes. The DAR engine, the freshness envelope, Source Profiles, and the FreshContext Specification are the moat.
 
@@ -80,9 +89,52 @@ See [Core / MCP Boundary](./docs/CORE_MCP_BOUNDARY.md) for the current package b
 
 ---
 
-## The intelligence feed
+## Primary MCP interface
 
-Beyond the per-call envelope, the production FreshContext deployment exposes a continuous, decay-scored, deduplicated feed:
+The clearest MCP path is `evaluate_context`.
+
+It accepts candidate context from any retriever, agent, database, local script, note parser, or adapter output:
+
+```json
+{
+  "profile": "academic_research",
+  "intent": "citation_check",
+  "signals": [
+    {
+      "title": "Example source",
+      "content": "Candidate context text...",
+      "source": "https://example.com/source",
+      "source_type": "arxiv",
+      "published_at": "2026-05-24T12:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.92
+    }
+  ]
+}
+```
+
+FreshContext returns decision-first output:
+
+- Decision
+- Meaning
+- Action
+- Warnings
+- Source
+- Freshness
+- Rank score
+- Utility
+- Confidence
+- Why
+
+`evaluate_context` does not fetch URLs, crawl, scrape, browse, read folders, or call adapters. It only evaluates candidate context the caller provides.
+
+Current boundary: `evaluate_context` is part of the published npm/local stdio MCP server. The hosted Cloudflare Worker endpoint is a separate deployment surface and may lag npm package interfaces until a dedicated Worker sync pass.
+
+---
+
+## Advanced Worker/feed surface
+
+Beyond the per-call Core/MCP paths, the production Worker deployment exposes a continuous, decay-scored, deduplicated feed. This is an advanced deployment surface, not the required way to use FreshContext Core:
 
 ```
 GET /v1/intel/feed/:profile_id?limit=20&min_rt=0
@@ -94,7 +146,7 @@ Production endpoint: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
 ---
 
-## Named reference adapters
+## Reference adapters
 
 The repo ships named reference adapters that demonstrate how different source classes can become FreshContext-compatible. Each adapter keeps its own name because it represents a source boundary; the adapter count is operational proof, not the product headline.
 
@@ -130,7 +182,7 @@ The repo ships named reference adapters that demonstrate how different source cl
 | `extract_finance_landscape` | 5 | Finance + HN + Reddit + GitHub + changelog |
 | `extract_company_landscape` | 5 | The full picture on any company |
 
-### Unique — not available in any other MCP server
+### Official, regulatory, and procurement sources
 | Adapter | Source | What it returns |
 |---|---|---|
 | `extract_changelog` | GitHub Releases / npm / auto-discover | Update history from any repo, package, or website |
@@ -292,6 +344,14 @@ Minimal shape:
 
 This local demo does not fetch URLs, crawl, or read folders. It evaluates candidate context you provide and returns decision-first output: Decision, Meaning, Action, Warnings, and supporting metrics.
 
+In an MCP client, use `evaluate_context` when you already have candidate context from another retriever, database, agent, or script:
+
+```text
+Use evaluate_context with profile "academic_research", intent "citation_check", and these candidate signals: [...]
+```
+
+Use the named reference adapters when you want FreshContext's current MCP package to fetch public source examples for you.
+
 **Should I build this idea?**
 ```
 Use extract_idea_landscape with idea "procurement intelligence saas"
@@ -351,6 +411,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 - [x] Live before/after demo at `/demo`
 - [x] METHODOLOGY.md — formal IP and engineering documentation
 - [x] Named reference adapters across intelligence, competitive research, market data, and composites
+- [x] Generic MCP `evaluate_context` tool for caller-provided candidate context
 - [x] Core-backed envelope generation shared by npm/MCP and the Cloudflare Worker
 - [x] Cloudflare Workers deployment — global edge, KV cache, KV rate limiting
 - [x] Published on npm and listed for MCP usage; Apify/feed assets are separated from the normal MCP runtime package
@@ -366,7 +427,7 @@ Future work is organized in [FreshContext Future Lanes](./docs/FUTURE_LANES.md).
 
 ## Contributing
 
-PRs welcome. New adapters are the highest-value contribution — see `src/adapters/` for the pattern and [`FRESHCONTEXT_SPEC.md`](./FRESHCONTEXT_SPEC.md) for the contract any adapter must fulfil.
+PRs welcome. The highest-value contributions improve the caller-provided context path, decision output, host integrations, and FreshContext-compatible signal quality. New reference adapters are useful when they preserve source boundaries and emit timestamped, failure-honest context — see `src/adapters/` for examples and [`FRESHCONTEXT_SPEC.md`](./FRESHCONTEXT_SPEC.md) for the compatibility contract.
 
 If you're building something FreshContext-compatible, open an issue and we'll add you to the ecosystem list.
 

--- a/docs/CODEX_MCP_USAGE.md
+++ b/docs/CODEX_MCP_USAGE.md
@@ -12,7 +12,7 @@ The verified local server entrypoint is:
 & '<node-executable>' '<repo-root>\dist\server.js'
 ```
 
-The MCP server exposes 21 tools. The local smoke test verifies the package version, server version, expected tool count, and representative tool calls.
+The MCP server exposes 22 tools: the front-door `evaluate_context` tool plus 21 read-only reference adapters. The local smoke test verifies the package version, server version, expected tool count, the generic context-evaluation path, and representative adapter calls.
 
 No credential is required for the local stdio smoke path.
 
@@ -85,7 +85,7 @@ Expected result:
   "ok": true,
   "package_version": "0.3.18",
   "server_version": "0.3.18",
-  "tool_count": 21
+  "tool_count": 22
 }
 ```
 
@@ -112,5 +112,5 @@ If Codex cannot start the server:
 - Confirm `dist/server.js` exists. If not, run `npm run build`.
 - Confirm Node is installed with `node -v`. The package requires Node.js 20 or newer.
 - If `node` is not found by Codex, use the full executable path from `node -p "process.execPath"`.
-- Run `npm run smoke:stdio` from the repository root and confirm `tool_count` is 21.
+- Run `npm run smoke:stdio` from the repository root and confirm `tool_count` is 22.
 - If the remote setup fails, verify network access, `npx` availability, and the remote endpoint separately. Do not treat remote failure as evidence that local stdio is broken.

--- a/docs/CORE_API.md
+++ b/docs/CORE_API.md
@@ -110,7 +110,7 @@ Public exports:
 - `SourceFailurePolicy`
 - `SourceSurface`
 
-They reframe the 21 MCP tools as reference adapters and source-profile examples instead of the product identity. They do not implement `retrieve(...)`, Operator mode, adapter selection, crawling, local file search, or any host/runtime behavior.
+They reframe the 21 named adapter tools as reference adapters and source-profile examples instead of the product identity. The MCP server also exposes `evaluate_context` as the generic caller-provided context evaluation path. Source Profiles do not implement `retrieve(...)`, Operator mode, adapter selection, crawling, local file search, or any host/runtime behavior.
 
 ## Decision Helper
 

--- a/docs/CORE_MCP_BOUNDARY.md
+++ b/docs/CORE_MCP_BOUNDARY.md
@@ -52,6 +52,7 @@ Live today:
 
 - npm package: `freshcontext-mcp@0.3.18`
 - MCP stdio server and published binary: `freshcontext-mcp`
+- `evaluate_context` MCP tool for caller-provided candidate context
 - 21 named read-only reference adapters
 - Core signal evaluation
 - Source Profiles

--- a/docs/FUTURE_LANES.md
+++ b/docs/FUTURE_LANES.md
@@ -12,6 +12,7 @@ Live today:
 
 - npm package: `freshcontext-mcp@0.3.18`
 - MCP stdio server
+- `evaluate_context` MCP tool for caller-provided candidate context
 - 21 read-only reference adapters
 - Core signal evaluation
 - Source Profiles
@@ -51,7 +52,7 @@ Goal:
 Let any caller provide candidate context and get decision-ready output.
 ```
 
-Possible MCP tool:
+Current live MCP path:
 
 ```text
 evaluate_context
@@ -64,7 +65,7 @@ No fetching, crawling, browsing, folder reading, or retrieval orchestration.
 Only evaluate caller-provided candidate context.
 ```
 
-This lane should start with an audit before implementation. Tool count changes only if the tool lands.
+Next work in this lane should focus on CLI, SDK, and REST ergonomics over the same caller-provided signal shape.
 
 ## Lane 3: Multi-Agent Context Handoff Proof
 

--- a/docs/SOURCE_PROFILES.md
+++ b/docs/SOURCE_PROFILES.md
@@ -88,7 +88,7 @@ It does not add `retrieve(...)`, Operator mode, adapter selection, local file se
 
 ## Adapter Registry Metadata
 
-As of Pass 8-S, the 21 MCP tools are also represented as adapter metadata. The registry maps each current tool name to a future adapter identity, Source Profile, output mode, runtime kind, and migration risk.
+As of Pass 8-S, the 21 named adapter tools are also represented as adapter metadata. The registry maps each adapter tool name to a future adapter identity, Source Profile, output mode, runtime kind, and migration risk. The generic `evaluate_context` MCP tool is not an adapter; it is a host interface over caller-provided candidate context.
 
 This registry is metadata-only. It does not change MCP behavior, adapter implementation behavior, Worker behavior, REST behavior, Core evaluation behavior, or runtime transport. It exists to make future extraction deliberate instead of ad hoc.
 

--- a/package-script-guard.mjs
+++ b/package-script-guard.mjs
@@ -101,6 +101,7 @@ const commands = {
       "tests/coreApiContract.test.ts",
       "tests/corePipeline.test.ts",
       "tests/decision.test.ts",
+      "tests/evaluateContextTool.test.ts",
       "tests/restHandler.test.ts",
       "tests/sourceProfiles.test.ts",
       "tests/adapterRegistry.test.ts",

--- a/scripts/smoke-stdio.mjs
+++ b/scripts/smoke-stdio.mjs
@@ -51,9 +51,34 @@ try {
 
   const tools = await client.listTools();
   const names = tools.tools.map((tool) => tool.name).sort();
-  assert(names.length === 21, `Expected 21 tools, got ${names.length}: ${names.join(", ")}`);
+  assert(names.length === 22, `Expected 22 tools, got ${names.length}: ${names.join(", ")}`);
+  assert(names.includes("evaluate_context"), "Missing evaluate_context");
   assert(names.includes("extract_hackernews"), "Missing extract_hackernews");
   assert(names.includes("extract_finance"), "Missing extract_finance");
+
+  const evaluateContext = textOf(await client.callTool({
+    name: "evaluate_context",
+    arguments: {
+      profile: "academic_research",
+      intent: "citation_check",
+      now: "2026-05-24T13:00:00.000Z",
+      signals: [
+        {
+          title: "Fresh research source",
+          content: "A relevant academic source with a reliable publication date.",
+          source: "https://arxiv.org/abs/2605.12345",
+          source_type: "arxiv",
+          published_at: "2026-05-24T12:00:00.000Z",
+          retrieved_at: "2026-05-24T13:00:00.000Z",
+          semantic_score: 0.94,
+          date_confidence: "high",
+        },
+      ],
+    },
+  }));
+  assert(/FreshContext evaluate_context/.test(evaluateContext), "evaluate_context missing title");
+  assert(/Decision:\s+Cite as primary/i.test(evaluateContext), "evaluate_context missing decision-first output");
+  assert(/\[FRESHCONTEXT_EVALUATION_JSON\]/.test(evaluateContext), "evaluate_context missing structured JSON block");
 
   const hnText = textOf(await client.callTool({
     name: "extract_hackernews",

--- a/scripts/trust-scan.mjs
+++ b/scripts/trust-scan.mjs
@@ -113,14 +113,14 @@ const SEVERITY_RANK = {
 };
 
 const FRESHCONTEXT_MCP_PACKAGE_NAME = "freshcontext-mcp";
-const FRESHCONTEXT_MCP_EXPECTED_TOOL_COUNT = 21;
+const FRESHCONTEXT_MCP_EXPECTED_TOOL_COUNT = 22;
 
 const CLAIM_SURFACE_CONFIG_FILES = new Set([
   "package.json",
   "server.json"
 ]);
 
-const STALE_TOOL_COUNT_CLAIM_PATTERN = /\b(?:20|11)\s+(?:MCP\s+)?tools\b/giu;
+const STALE_TOOL_COUNT_CLAIM_PATTERN = /\b(?:21|20|11)\s+(?:MCP\s+)?tools\b/giu;
 const YAHOO_CLAIM_PATTERN = /\byahoo\b/giu;
 
 const HA_PRI_BOUNDARY_PATTERNS = [
@@ -2124,7 +2124,7 @@ function checkToolCountClaims(state, claimCheck, claimSurfaces) {
     addClaimCheckFinding(state, claimCheck, {
       ruleId: "claim-check-tool-count-current",
       severity: "info",
-      message: `No stale current 20/11 tool-count claims were found in public/package claim surfaces. Expected count is ${expectedToolCount}.`,
+      message: `No stale current 21/20/11 tool-count claims were found in public/package claim surfaces. Expected count is ${expectedToolCount}.`,
       recommendation: "Keep public tool-count claims aligned with smoke/static evidence."
     });
   }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
   "name": "io.github.PrinceGabriel-lgtm/freshcontext",
-  "description": "Freshness-aware AI retrieval with 21 MCP tools for timestamped, decay-ranked live signals.",
+  "description": "Context integrity infrastructure for AI agents and retrieval systems. Evaluates caller-provided and adapter-sourced context before it reaches the model.",
   "repository": {
     "url": "https://github.com/PrinceGabriel-lgtm/freshcontext-mcp",
     "source": "github"

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,11 @@ import { secFilingsAdapter } from "./adapters/secFilings.js";
 import { gdeltAdapter } from "./adapters/gdelt.js";
 import { gebizAdapter } from "./adapters/gebiz.js";
 import { stampFreshness, formatForLLM } from "./tools/freshnessStamp.js";
+import {
+  EvaluateContextInputError,
+  evaluateContextInput,
+  formatEvaluateContextResult,
+} from "./tools/evaluateContext.js";
 import { SecurityError, formatSecurityError } from "./security.js";
 
 const server = new McpServer({
@@ -26,7 +31,50 @@ const server = new McpServer({
   version: "0.3.18",
 });
 
-// ─── Tool: extract_github ────────────────────────────────────────────────────
+const signalInputSchema = z.object({
+  id: z.string().optional(),
+  source: z.string().min(1).describe("Source URL, URI, document id, or stable source label."),
+  source_type: z.string().optional().describe("Source type such as arxiv, jobs, official_docs, custom, or user_provided."),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  published_at: z.string().nullable().optional(),
+  content_date: z.string().nullable().optional(),
+  retrieved_at: z.string().nullable().optional(),
+  semantic_score: z.number().optional().describe("Optional relevance score from 0..1. Core clamps out-of-range values."),
+  date_confidence: z.enum(["high", "medium", "low", "unknown"]).optional(),
+  freshness_confidence: z.enum(["high", "medium", "low"]).optional(),
+  status: z.enum(["success", "partial", "stale", "failed", "unknown"]).optional(),
+  metadata: z.record(z.unknown()).optional(),
+}).passthrough();
+
+// ─── Tool: evaluate_context ─────────────────────────────────────────────────
+server.registerTool(
+  "evaluate_context",
+  {
+    description:
+      "Evaluate caller-provided candidate context and return decision-ready output. This is the primary FreshContext judgment path: it does not fetch, crawl, scrape, browse, read folders, or call adapters.",
+    inputSchema: z.object({
+      profile: z.string().min(1).describe("Source Profile id, e.g. academic_research, jobs_opportunities, market_finance, official_docs, local_custom."),
+      intent: z.string().min(1).describe("Intent Profile id, e.g. citation_check, student_research, developer_adoption, job_search, market_watch, business_due_diligence, medical_literature_triage."),
+      signals: z.array(signalInputSchema).min(1).describe("Candidate context items provided by the caller. FreshContext evaluates these; it does not retrieve them."),
+      now: z.string().optional().describe("Optional ISO timestamp for deterministic evaluation."),
+    }),
+    annotations: { readOnlyHint: true, openWorldHint: false },
+  },
+  async ({ profile, intent, signals, now }) => {
+    try {
+      const result = evaluateContextInput({ profile, intent, signals, now });
+      return { content: [{ type: "text", text: formatEvaluateContextResult(result) }] };
+    } catch (err) {
+      if (err instanceof EvaluateContextInputError) {
+        return { content: [{ type: "text", text: `[FreshContext evaluate_context error]\n${err.message}` }] };
+      }
+      return { content: [{ type: "text", text: formatSecurityError(err) }] };
+    }
+  }
+);
+
+// ─── Reference adapter: extract_github ───────────────────────────────────────
 server.registerTool(
   "extract_github",
   {

--- a/src/tools/evaluateContext.ts
+++ b/src/tools/evaluateContext.ts
@@ -1,0 +1,192 @@
+import {
+  evaluateSignals,
+  getSourceProfile,
+  interpretEvaluations,
+} from "../core/index.js";
+import type {
+  ContextDecisionResult,
+  CoreSignalEvaluationOptions,
+  CoreSignalEvaluationResult,
+  FreshContextSignalInput,
+  IntentProfileId,
+  SourceProfile,
+} from "../core/index.js";
+
+const SUPPORTED_INTENTS: readonly IntentProfileId[] = [
+  "citation_check",
+  "student_research",
+  "developer_adoption",
+  "job_search",
+  "market_watch",
+  "business_due_diligence",
+  "medical_literature_triage",
+];
+
+export class EvaluateContextInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EvaluateContextInputError";
+  }
+}
+
+export interface EvaluateContextInput {
+  profile: string;
+  intent: string;
+  signals: unknown;
+  now?: string;
+}
+
+export interface EvaluateContextItem {
+  evaluation: CoreSignalEvaluationResult;
+  decision: ContextDecisionResult;
+}
+
+export interface EvaluateContextResult {
+  profile: SourceProfile;
+  intent: IntentProfileId;
+  items: EvaluateContextItem[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIntentProfileId(value: string): value is IntentProfileId {
+  return (SUPPORTED_INTENTS as readonly string[]).includes(value);
+}
+
+function validateSignal(value: unknown, index: number): FreshContextSignalInput {
+  if (!isRecord(value)) {
+    throw new EvaluateContextInputError(`signals[${index}] must be an object.`);
+  }
+  if (typeof value.source !== "string" || value.source.trim().length === 0) {
+    throw new EvaluateContextInputError(`signals[${index}].source must be a non-empty string.`);
+  }
+  if (
+    (typeof value.title !== "string" || value.title.trim().length === 0)
+    && (typeof value.content !== "string" || value.content.trim().length === 0)
+  ) {
+    throw new EvaluateContextInputError(`signals[${index}] must include title or content.`);
+  }
+  return {
+    ...value,
+    source: value.source,
+    title: typeof value.title === "string" ? value.title : undefined,
+    content: typeof value.content === "string" ? value.content : undefined,
+  } as FreshContextSignalInput;
+}
+
+export function evaluateContextInput(input: EvaluateContextInput): EvaluateContextResult {
+  const profile = getSourceProfile(input.profile);
+  if (!profile) {
+    throw new EvaluateContextInputError(`Unknown source profile: ${input.profile}.`);
+  }
+  if (!isIntentProfileId(input.intent)) {
+    throw new EvaluateContextInputError(`Unsupported intent profile: ${input.intent}.`);
+  }
+  if (!Array.isArray(input.signals)) {
+    throw new EvaluateContextInputError("signals must be an array.");
+  }
+  if (input.signals.length === 0) {
+    throw new EvaluateContextInputError("signals must contain at least one candidate context item.");
+  }
+
+  const signals = input.signals.map(validateSignal);
+  const options: CoreSignalEvaluationOptions = input.now ? { now: input.now } : {};
+  const evaluations = evaluateSignals(signals, options);
+  const decisions = interpretEvaluations(evaluations, {
+    sourceProfile: profile,
+    intentProfile: input.intent,
+  });
+
+  return {
+    profile,
+    intent: input.intent,
+    items: evaluations.map((evaluation, index) => ({
+      evaluation,
+      decision: decisions[index],
+    })),
+  };
+}
+
+function sourceTitle(evaluation: CoreSignalEvaluationResult): string {
+  if (evaluation.signal.title) return evaluation.signal.title;
+  if (evaluation.signal.content) return evaluation.signal.content.slice(0, 80);
+  return evaluation.signal.source;
+}
+
+function formatFreshness(score: number | null): string {
+  return score === null ? "unknown" : `${Math.round(score)}/100`;
+}
+
+function formatRank(score: number): string {
+  return score.toFixed(3);
+}
+
+function formatUtility(score: number): string {
+  return `${Number(score.toFixed(1))}/100`;
+}
+
+function formatList(values: string[]): string {
+  return values.length > 0 ? values.join("; ") : "None";
+}
+
+export function formatEvaluateContextResult(result: EvaluateContextResult): string {
+  const lines: string[] = [
+    "FreshContext evaluate_context",
+    "Candidate context -> Core evaluation -> decision-ready context",
+    "",
+    `Profile: ${result.profile.profile_id}`,
+    `Purpose: ${result.profile.purpose}`,
+    `Intent: ${result.intent}`,
+    "",
+  ];
+
+  result.items.forEach((item, index) => {
+    const { evaluation, decision } = item;
+    lines.push(
+      `${index + 1}. ${sourceTitle(evaluation)}`,
+      `   Decision: ${decision.label}`,
+      `   Meaning: ${decision.meaning}`,
+      `   Action: ${decision.action}`,
+      `   Warnings: ${formatList(decision.warnings)}`,
+      `   Source: ${evaluation.signal.source}`,
+      `   Freshness: ${formatFreshness(evaluation.freshness_score)}`,
+      `   Rank score: ${formatRank(evaluation.ranked.final_score)}`,
+      `   Utility: ${formatUtility(evaluation.utility.score)}`,
+      `   Confidence: ${evaluation.ranked.confidence}`,
+      `   Why: ${evaluation.explanation}`,
+      ""
+    );
+  });
+
+  const structured = {
+    profile: result.profile.profile_id,
+    intent: result.intent,
+    results: result.items.map((item, index) => ({
+      index: index + 1,
+      title: sourceTitle(item.evaluation),
+      source: item.evaluation.signal.source,
+      source_type: item.evaluation.signal.source_type,
+      decision: item.decision.decision,
+      label: item.decision.label,
+      meaning: item.decision.meaning,
+      action: item.decision.action,
+      warnings: item.decision.warnings,
+      reasons: item.decision.reasons,
+      freshness_score: item.evaluation.freshness_score,
+      rank_score: item.evaluation.ranked.final_score,
+      utility_score: item.evaluation.utility.score,
+      confidence: item.evaluation.ranked.confidence,
+      why: item.evaluation.explanation,
+    })),
+  };
+
+  lines.push(
+    "[FRESHCONTEXT_EVALUATION_JSON]",
+    JSON.stringify(structured, null, 2),
+    "[/FRESHCONTEXT_EVALUATION_JSON]"
+  );
+
+  return lines.join("\n");
+}

--- a/tests/evaluateContextTool.test.ts
+++ b/tests/evaluateContextTool.test.ts
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  EvaluateContextInputError,
+  evaluateContextInput,
+  formatEvaluateContextResult,
+} from "../src/tools/evaluateContext.js";
+
+const NOW = "2026-05-24T13:00:00.000Z";
+
+function validInput(overrides: Record<string, unknown> = {}) {
+  return {
+    profile: "academic_research",
+    intent: "citation_check",
+    now: NOW,
+    signals: [
+      {
+        title: "Fresh research source",
+        content: "A relevant academic source with a reliable publication date.",
+        source: "https://arxiv.org/abs/2605.12345",
+        source_type: "arxiv",
+        published_at: "2026-05-24T12:00:00.000Z",
+        retrieved_at: NOW,
+        semantic_score: 0.94,
+        date_confidence: "high",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test("evaluate_context returns decision-first output for caller-provided signals", () => {
+  const result = evaluateContextInput(validInput());
+  const text = formatEvaluateContextResult(result);
+
+  assert.equal(result.profile.profile_id, "academic_research");
+  assert.equal(result.intent, "citation_check");
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].decision.decision, "cite_as_primary");
+  assert.match(text, /Decision: Cite as primary/);
+  assert.match(text, /Meaning:/);
+  assert.match(text, /Action:/);
+  assert.match(text, /Warnings:/);
+  assert.match(text, /Freshness:/);
+  assert.match(text, /Rank score:/);
+  assert.match(text, /Utility:/);
+  assert.match(text, /Confidence:/);
+  assert.match(text, /Why:/);
+  assert.match(text, /\[FRESHCONTEXT_EVALUATION_JSON\]/);
+});
+
+test("evaluate_context rejects unknown source profiles", () => {
+  assert.throws(
+    () => evaluateContextInput(validInput({ profile: "unknown_profile" })),
+    (error) => error instanceof EvaluateContextInputError
+      && /Unknown source profile/.test(error.message)
+  );
+});
+
+test("evaluate_context rejects unsupported intent profiles", () => {
+  assert.throws(
+    () => evaluateContextInput(validInput({ intent: "write_me_a_trade" })),
+    (error) => error instanceof EvaluateContextInputError
+      && /Unsupported intent profile/.test(error.message)
+  );
+});
+
+test("evaluate_context rejects missing or non-array signals", () => {
+  assert.throws(
+    () => evaluateContextInput(validInput({ signals: undefined })),
+    /signals must be an array/
+  );
+  assert.throws(
+    () => evaluateContextInput(validInput({ signals: { source: "https://example.com" } })),
+    /signals must be an array/
+  );
+});
+
+test("evaluate_context rejects empty signal arrays", () => {
+  assert.throws(
+    () => evaluateContextInput(validInput({ signals: [] })),
+    /at least one candidate context item/
+  );
+});
+
+test("evaluate_context surfaces missing-date signals as needs verification", () => {
+  const result = evaluateContextInput(validInput({
+    signals: [
+      {
+        title: "Undated useful source",
+        content: "This source has useful content but no reliable date.",
+        source: "https://example.com/undated",
+        source_type: "arxiv",
+        published_at: null,
+        retrieved_at: NOW,
+        semantic_score: 0.62,
+        date_confidence: "unknown",
+      },
+    ],
+  }));
+
+  assert.equal(result.items[0].decision.decision, "needs_verification");
+  assert.equal(result.items[0].evaluation.freshness_score, null);
+});
+
+test("evaluate_context excludes failed or error-looking signals", () => {
+  const result = evaluateContextInput(validInput({
+    signals: [
+      {
+        title: "Blocked source",
+        content: "[ERROR] upstream blocked the request",
+        source: "https://example.com/blocked",
+        source_type: "arxiv",
+        published_at: "2026-05-24T12:00:00.000Z",
+        retrieved_at: NOW,
+        semantic_score: 0.99,
+      },
+    ],
+  }));
+
+  assert.equal(result.items[0].decision.decision, "exclude");
+  assert.equal(result.items[0].evaluation.signal.status, "failed");
+});
+
+test("evaluate_context requires each signal to carry source plus title or content", () => {
+  assert.throws(
+    () => evaluateContextInput(validInput({
+      signals: [{ title: "Missing source", content: "No source here." }],
+    })),
+    /source must be a non-empty string/
+  );
+  assert.throws(
+    () => evaluateContextInput(validInput({
+      signals: [{ source: "https://example.com/no-content" }],
+    })),
+    /must include title or content/
+  );
+});
+
+test("evaluate_context helper does not import host runtime or retrieval modules", () => {
+  const source = readFileSync("src/tools/evaluateContext.ts", "utf8");
+
+  assert.doesNotMatch(source, /fetch\(|readFile|readdir|createServer|listen\(/);
+  assert.doesNotMatch(source, /McpServer|WebStandardStreamableHTTPServerTransport|worker\/src|\.\.\/worker/);
+  assert.doesNotMatch(source, /\bD1\b|\bKV\b|\bCACHE\b|retrieve\(|Operator/);
+});

--- a/tests/trustScan.test.mjs
+++ b/tests/trustScan.test.mjs
@@ -446,7 +446,7 @@ test("claim check reports matching package and server versions", async () => {
   try {
     await writeFreshContextPackageJson(fixture, "1.2.3");
     await writeServerJson(fixture, "1.2.3");
-    await writeFile(path.join(fixture, "README.md"), "FreshContext ships 21 tools.\n", "utf8");
+    await writeFile(path.join(fixture, "README.md"), "FreshContext ships 22 tools.\n", "utf8");
 
     const result = runScanner(fixture, ["--claim-check", "--json"]);
     assert.equal(result.status, 0, result.stderr);
@@ -454,7 +454,7 @@ test("claim check reports matching package and server versions", async () => {
     const report = JSON.parse(result.stdout);
     assert.equal(report.claimChecks.length, 1);
     assert.equal(report.projects[0].claimCheck.packageName, "freshcontext-mcp");
-    assert.equal(report.projects[0].claimCheck.expectedToolCount, 21);
+    assert.equal(report.projects[0].claimCheck.expectedToolCount, 22);
     assert.equal(report.findings.some((finding) => finding.ruleId === "claim-check-version-match" && finding.effectiveSeverity === "info"), true);
     assert.equal(report.findings.some((finding) => finding.category === "claim_check"), true);
   } finally {
@@ -467,7 +467,7 @@ test("claim check fails mismatched package and server versions", async () => {
   try {
     await writeFreshContextPackageJson(fixture, "1.2.3");
     await writeServerJson(fixture, "1.2.4");
-    await writeFile(path.join(fixture, "README.md"), "FreshContext ships 21 tools.\n", "utf8");
+    await writeFile(path.join(fixture, "README.md"), "FreshContext ships 22 tools.\n", "utf8");
 
     const result = runScanner(fixture, ["--claim-check", "--fail-on", "fail", "--json"]);
     assert.equal(result.status, 1);


### PR DESCRIPTION
﻿## Summary

Adds `evaluate_context` as the generic MCP front-door tool for caller-provided candidate context and reframes the public package surface around FreshContext Core as the context judgment layer.

This makes the code reflect the product direction:

```txt
candidate context
-> FreshContext Core
-> decision-ready context
-> model / agent / app
```

## Changes

- Adds `src/tools/evaluateContext.ts`
- Registers `evaluate_context` near the top of `src/server.ts`
- Adds `tests/evaluateContextTool.test.ts`
- Updates stdio smoke from 21 to 22 tools
- Updates Trust Scanner expected MCP tool count to 22
- Reframes README/server metadata/spec/methodology/docs away from "21 tools" as the product identity
- Keeps 21 named adapters framed as read-only reference adapters / proof surfaces

## evaluate_context

The new MCP tool accepts caller-provided context:

```json
{
  "profile": "academic_research",
  "intent": "citation_check",
  "signals": [
    {
      "title": "...",
      "content": "...",
      "source": "...",
      "source_type": "...",
      "published_at": "...",
      "retrieved_at": "...",
      "semantic_score": 0.92
    }
  ]
}
```

It returns decision-first output:

- Decision
- Meaning
- Action
- Warnings
- Source
- Freshness
- Rank score
- Utility
- Confidence
- Why

It also includes a structured `[FRESHCONTEXT_EVALUATION_JSON]` block for agents.

## Scope

This pass does not:

- fetch, crawl, scrape, browse, or read folders
- call adapters from `evaluate_context`
- change Core ranking behavior
- change Core evaluation behavior
- change REST handler behavior
- change Worker behavior
- change adapter behavior
- deploy
- publish npm
- bump version

`evaluate_context` is live in the npm/local stdio MCP server. The hosted Worker remote is a separate deployment surface and may lag until a dedicated Worker sync pass.

## Validation

- `npm run build`
- `npm test` — 181 passed, 0 skipped
- `npm run smoke:stdio` — 22 tools, v0.3.18
- `npm run trust:gate` — 0 effective fail findings
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm audit --omit=dev` — 0 vulnerabilities
- `git diff --check`
- hidden-character scan — no output

## Focused audit

- No diffs in `worker`, `src/rest`, `src/core`, or `src/adapters`
- `evaluate_context` helper does not import MCP/Worker/runtime/fetch/file-read surfaces
