### PR TITLE
Pass 11-D — Prepare 0.3.19 release sync

### DIFF
--- a/FRESHCONTEXT_SPEC.md
+++ b/FRESHCONTEXT_SPEC.md
@@ -248,7 +248,7 @@ Claude Desktop is a supported MCP client, but FreshContext Core is not Claude-de
 
 The canonical reference implementation of this specification is:
 
-**freshcontext-mcp@0.3.18** — an MCP server with `evaluate_context` for caller-provided candidate context plus 21 read-only reference adapters covering:
+**freshcontext-mcp@0.3.19** — an MCP server with `evaluate_context` for caller-provided candidate context plus 21 read-only reference adapters covering:
 
 **Intelligence:** GitHub, Hacker News, Google Scholar, arXiv, Reddit
 
@@ -282,7 +282,7 @@ The canonical reference implementation of this specification is:
 - Added Core-backed envelope/scoring implementation status.
 - Added optional context-conditioned scoring language without changing the envelope contract.
 - Clarified MCP as one interface over the FreshContext methodology.
-- Updated reference implementation language for freshcontext-mcp@0.3.18, `evaluate_context`, and 21 read-only reference adapters.
+- Updated reference implementation language for freshcontext-mcp@0.3.19, `evaluate_context`, and 21 read-only reference adapters.
 
 ### Version 1.1 — April 2026
 - Added Composite Adapters section

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -356,7 +356,7 @@ For technical integrators, auditors, and future platform partners:
 
 5. **The Store / Ledger design** — support for recurring watched queries, historical signal accumulation, D1-backed storage, and time-series auditability.
 
-6. **The Reference Implementation** — `freshcontext-mcp@0.3.18`, the `evaluate_context` MCP interface, and 21 read-only reference adapters, listed on the official MCP Registry and npm. Deployed globally on Cloudflare's edge infrastructure.
+6. **The Reference Implementation** — `freshcontext-mcp@0.3.19`, the `evaluate_context` MCP interface, and 21 read-only reference adapters, listed on npm and the MCP Registry. The hosted Worker endpoint is a separate deployment surface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 ## Roadmap
 
 - [x] FreshContext Specification v1.2 published (MIT, open standard)
-- [x] DAR engine with proprietary λ constants (v0.3.18)
+- [x] DAR engine with proprietary λ constants (v0.3.19)
 - [x] Ha-Pri v1 provenance signatures on stored signals
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`

--- a/docs/CODEX_MCP_USAGE.md
+++ b/docs/CODEX_MCP_USAGE.md
@@ -83,8 +83,8 @@ Expected result:
 ```json
 {
   "ok": true,
-  "package_version": "0.3.18",
-  "server_version": "0.3.18",
+  "package_version": "0.3.19",
+  "server_version": "0.3.19",
   "tool_count": 22
 }
 ```

--- a/docs/CORE_MCP_BOUNDARY.md
+++ b/docs/CORE_MCP_BOUNDARY.md
@@ -50,7 +50,7 @@ Worker/site surfaces own deployment concerns:
 
 Live today:
 
-- npm package: `freshcontext-mcp@0.3.18`
+- npm package: `freshcontext-mcp@0.3.19`
 - MCP stdio server and published binary: `freshcontext-mcp`
 - `evaluate_context` MCP tool for caller-provided candidate context
 - 21 named read-only reference adapters

--- a/docs/FUTURE_LANES.md
+++ b/docs/FUTURE_LANES.md
@@ -10,7 +10,7 @@ The current package boundary is documented in [Core / MCP Boundary](./CORE_MCP_B
 
 Live today:
 
-- npm package: `freshcontext-mcp@0.3.18`
+- npm package: `freshcontext-mcp@0.3.19`
 - MCP stdio server
 - `evaluate_context` MCP tool for caller-provided candidate context
 - 21 read-only reference adapters

--- a/docs/IP_INVENTORY.md
+++ b/docs/IP_INVENTORY.md
@@ -141,7 +141,7 @@ Checklist:
 Known package presence:
 
 - npm package: `freshcontext-mcp`
-- current local package version: `0.3.18`
+- current local package version: `0.3.19`
 - MCP registry name in `package.json`: `io.github.PrinceGabriel-lgtm/freshcontext`
 - Ops Pulse npm package metadata: `freshcontext-ops-pulse`, local version `0.1.1`
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,8 +1,25 @@
 # FreshContext Release Notes
 
+## 0.3.19
+
+FreshContext 0.3.19 syncs the public MCP package with the new generic `evaluate_context` interface.
+
+### Context Evaluation Front Door
+
+- Adds `evaluate_context` as the primary MCP tool for caller-provided candidate context.
+- Returns decision-first output for agents and users: decision, meaning, action, warnings, source, freshness, rank score, utility, confidence, and explanation.
+- Keeps the boundary explicit: `evaluate_context` does not fetch, crawl, scrape, browse, read folders, or call adapters.
+- Updates stdio smoke and Trust Scanner claim checks to expect 22 MCP tools: `evaluate_context` plus 21 read-only reference adapters.
+
+### Public Framing
+
+- Reframes the MCP package around FreshContext as context integrity infrastructure, not a 21-tool toolbox.
+- Keeps the 21 adapter tools as read-only reference adapters and proof surfaces.
+- Updates package-facing docs/spec language to point first at `candidate context -> FreshContext Core -> decision-ready context`.
+
 ## 0.3.18
 
-FreshContext 0.3.18 is the current published npm package release. It makes the MCP/Core package easier to install, validate, and explain without changing the deployed Worker runtime.
+FreshContext 0.3.18 made the MCP/Core package easier to install, validate, and explain without changing the deployed Worker runtime.
 
 ### Core and Context Evaluation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freshcontext-mcp",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freshcontext-mcp",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "freshcontext-mcp",
   "mcpName": "io.github.PrinceGabriel-lgtm/freshcontext",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Context integrity infrastructure for AI agents and retrieval systems. Score, explain, and wrap candidate context before it reaches the model.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/PrinceGabriel-lgtm/freshcontext-mcp",
     "source": "github"
   },
-  "version": "0.3.18",
+  "version": "0.3.19",
   "website_url": "https://freshcontext-site.pages.dev",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "freshcontext-mcp",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import { SecurityError, formatSecurityError } from "./security.js";
 
 const server = new McpServer({
   name: "freshcontext-mcp",
-  version: "0.3.18",
+  version: "0.3.19",
 });
 
 const signalInputSchema = z.object({
@@ -47,7 +47,7 @@ const signalInputSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
 }).passthrough();
 
-// ─── Tool: evaluate_context ─────────────────────────────────────────────────
+// Tool: evaluate_context
 server.registerTool(
   "evaluate_context",
   {


### PR DESCRIPTION
﻿## Summary

Prepares FreshContext MCP `0.3.19` so the published package can include the new `evaluate_context` front-door tool.

This is release sync only. It does not publish npm, deploy, tag, or change runtime behavior beyond aligning version metadata and release notes.

## Changes

- Bumps package metadata to `0.3.19`
- Bumps `server.json` package metadata to `0.3.19`
- Updates MCP runtime `serverInfo.version` to `0.3.19`
- Adds `0.3.19` release notes for `evaluate_context`
- Updates package-facing docs/spec references from `0.3.18` to `0.3.19`
- Clarifies that the hosted Worker endpoint is a separate deployment surface

## Release purpose

`0.3.19` syncs the public npm/local stdio MCP package with the new primary interface:

```txt
evaluate_context
```

The expected public MCP surface becomes:

```txt
22 tools = evaluate_context + 21 read-only reference adapters
```

## Validation

- `npm run build`
- `npm test` — 181 passed, 0 skipped
- `npm run smoke:stdio` — 22 tools, v0.3.19
- `npm run trust:gate` — 0 effective fail findings
- `npx tsc --noEmit`
- `cd worker && npx tsc --noEmit`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack --dry-run --json`
- `npm pack`
- fresh packed install smoke:
  - `npm audit --omit=dev` clean
  - `dist/server.js` present
  - `dist/tools/evaluateContext.js` present
  - `dist/apify.js` absent
  - Apify/Crawlee/file-type absent
  - installed `npm start` returns 22 tools / `v0.3.19`
  - installed binary returns 22 tools / `v0.3.19`
  - installed `evaluate_context` returns decision-first output with structured JSON
- `git diff --check`
- hidden-character scan — no output

## Scope

No npm publish.
No deploy.
No git tag.
No Worker deploy.
No package registry update.
No Core/ranking/adapter behavior changes.

After merge, the next step is the actual release execution gate: tag and npm publish decision for `0.3.19`.
