### PR TITLE
Pass 11-E — Client setup guide and latest install smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The repo ships named reference adapters that demonstrate how different source cl
 
 ## Quick start
 
+For Claude Desktop, Codex, `npx`, global npm, and source-checkout setup, see the concise [client setup guide](./docs/CLIENT_SETUP.md).
+
 ### Cloud (no install)
 
 Add to your Claude Desktop config and restart:

--- a/docs/CLIENT_SETUP.md
+++ b/docs/CLIENT_SETUP.md
@@ -1,0 +1,166 @@
+# FreshContext Client Setup
+
+FreshContext is live as an MCP stdio package on npm.
+
+Use this guide when connecting Claude Desktop, Codex, or another MCP-compatible client to the published package.
+
+## What You Should See
+
+FreshContext `0.3.19` exposes:
+
+```text
+22 tools = evaluate_context + 21 read-only reference adapters
+```
+
+The primary interface is:
+
+```text
+evaluate_context
+```
+
+Use it when another retriever, agent, database, note parser, PDF extractor, or local script already has candidate context and needs FreshContext to judge what deserves to reach the model.
+
+## Claude Desktop: Published Package
+
+Add this to your Claude Desktop config, then restart Claude.
+
+macOS:
+
+```text
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+Windows:
+
+```text
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+Config:
+
+```json
+{
+  "mcpServers": {
+    "freshcontext": {
+      "command": "npx",
+      "args": ["-y", "freshcontext-mcp@latest"]
+    }
+  }
+}
+```
+
+If you previously installed an older global package, refresh it:
+
+```bash
+npm install -g freshcontext-mcp@latest
+```
+
+Then this config is also valid when the global npm bin path is visible to Claude:
+
+```json
+{
+  "mcpServers": {
+    "freshcontext": {
+      "command": "freshcontext-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+## Codex: Local MCP Config
+
+For Codex local MCP config, use the published package through `npx`:
+
+```toml
+[mcp_servers.freshcontext]
+command = "npx"
+args = ["-y", "freshcontext-mcp@latest"]
+```
+
+If you prefer a source checkout while developing FreshContext itself:
+
+```toml
+[mcp_servers.freshcontext]
+command = "node"
+args = ["C:\\Users\\YOUR_USERNAME\\path\\to\\freshcontext-mcp\\dist\\server.js"]
+```
+
+Keep local MCP config files out of git. Do not commit machine-specific paths or credentials.
+
+## Source Checkout Setup
+
+Use this when contributing to FreshContext itself:
+
+```bash
+git clone https://github.com/PrinceGabriel-lgtm/freshcontext-mcp
+cd freshcontext-mcp
+npm install
+npm run build
+npm run smoke:stdio
+```
+
+Expected smoke result:
+
+```json
+{
+  "ok": true,
+  "package_version": "0.3.19",
+  "server_version": "0.3.19",
+  "tool_count": 22
+}
+```
+
+## Remote Worker Boundary
+
+The repository also declares a remote Streamable HTTP MCP endpoint:
+
+```text
+https://freshcontext-mcp.gimmanuel73.workers.dev/mcp
+```
+
+Some clients can use `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "freshcontext-remote": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://freshcontext-mcp.gimmanuel73.workers.dev/mcp"]
+    }
+  }
+}
+```
+
+The npm/local stdio package is the current primary tested client path. The hosted Worker endpoint is a separate deployment surface and may lag npm package interfaces until a dedicated Worker sync pass.
+
+## ChatGPT / OpenAI Connector Boundary
+
+Claude and Codex MCP paths are documented now.
+
+ChatGPT connector compatibility requires a separate search/fetch compatibility audit before being claimed. Do not assume ChatGPT connector support from Claude/Codex MCP compatibility alone.
+
+## Quick Test Prompt
+
+After connecting a client, ask it to use `evaluate_context` with this candidate context:
+
+```json
+{
+  "profile": "academic_research",
+  "intent": "citation_check",
+  "signals": [
+    {
+      "title": "Fresh research source",
+      "content": "A relevant academic source with a reliable publication date.",
+      "source": "https://arxiv.org/abs/2605.12345",
+      "source_type": "arxiv",
+      "published_at": "2026-05-24T12:00:00.000Z",
+      "retrieved_at": "2026-05-24T13:00:00.000Z",
+      "semantic_score": 0.94,
+      "date_confidence": "high"
+    }
+  ]
+}
+```
+
+Expected result: decision-first output with a decision, meaning, action, warnings, supporting scores, and a structured FreshContext evaluation JSON block.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dist/",
     "!dist/apify.js",
     "docs/API_DESIGN.md",
+    "docs/CLIENT_SETUP.md",
     "docs/CODEX_MCP_USAGE.md",
     "docs/CORE_MCP_BOUNDARY.md",
     "docs/CORE_API.md",


### PR DESCRIPTION
﻿## Summary

Adds a concise client setup guide for connecting the published `freshcontext-mcp@latest` package to MCP clients.

This keeps the install path clear now that `0.3.19` is live with the `evaluate_context` front door.

## Changes

- Adds `docs/CLIENT_SETUP.md`
- Links the guide from `README.md`
- Includes the guide in the npm package files allowlist

## Guide covers

- Claude Desktop via `npx freshcontext-mcp@latest`
- Claude Desktop via refreshed global install
- Codex local MCP config via `npx freshcontext-mcp@latest`
- Source checkout setup with `node dist/server.js`
- Stale global package refresh: `npm install -g freshcontext-mcp@latest`
- Expected 22-tool smoke result for `0.3.19`
- Remote Worker boundary via `mcp-remote`
- ChatGPT/OpenAI connector boundary: not claimed until separately audited

## Live client smoke

Verified against the published npm package:

- `npm view freshcontext-mcp version` -> `0.3.19`
- `npx -y freshcontext-mcp@latest` MCP smoke:
  - server version `0.3.19`
  - 22 tools
  - `evaluate_context` present
  - `evaluate_context` returns decision-first output and structured JSON
- temp global-style install with `npm install -g --prefix <temp> freshcontext-mcp@latest`:
  - server version `0.3.19`
  - 22 tools
  - `evaluate_context` present
  - `evaluate_context` returns decision-first output and structured JSON

## Validation

- `npm run build`
- `npm run smoke:stdio` — 22 tools, v0.3.19
- `npm run trust:gate` — 0 effective fail findings
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack --dry-run --json` — `docs/CLIENT_SETUP.md` included
- `git diff --check`
- hidden-character scan — no output

## Scope

Docs/package-surface only.

No runtime behavior changes.
No deploy.
No npm publish.
No version bump.
