### PR TITLE
docs: clarify FreshContext foundation and product roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,53 @@
 # FreshContext
 
-I asked Claude to help me find a job. It gave me a list of openings. I applied to three of them. Two didn't exist anymore. One had been closed for two years.
+**Build your context-integrity layer on an existing foundation.**
 
-Claude had no idea. It presented everything with the same confidence.
+FreshContext evaluates candidate information before it reaches model reasoning. It combines source-aware freshness, ranking, explanations, provenance readiness and explicit recommendations about how context should be used.
 
-That's the problem freshcontext fixes.
+Bring context from your retriever, database, agent or source adapter. Use the reusable Core inside your application, or connect through MCP. Shape the surrounding experience around your own workflows and platform.
 
-This repository is the integrated FreshContext Core/MCP package. FreshContext is the context judgment layer between retrieval and reasoning. Core is the reusable engine that scores, ranks, explains, and turns candidate context into decision-ready context; MCP is the first live host/interface over that engine.
+This repository is the integrated FreshContext Core/MCP package. Core owns evaluation; MCP is the first live host/interface. Your application decides how to act on the recommendations.
 
 [![npm version](https://img.shields.io/npm/v/freshcontext-mcp)](https://www.npmjs.com/package/freshcontext-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Registry](https://img.shields.io/badge/MCP%20Registry-Listed-blue)](https://registry.modelcontextprotocol.io)
 
-> **Live demo:** [freshcontext-mcp.gimmanuel73.workers.dev/demo](https://freshcontext-mcp.gimmanuel73.workers.dev/demo) — same model, same query, two completely different answers. Only the temporal layer changed.
+**Start here:** [Client setup](./docs/CLIENT_SETUP.md) · [Core API](./docs/CORE_API.md) · [Product roadmap](./docs/FUTURE_LANES.md#product-roadmap) · [Hosted demo](https://freshcontext-mcp.gimmanuel73.workers.dev/demo)
+
+## What you can build on today
+
+| Foundation | What it gives your application |
+|---|---|
+| **Core evaluation** | Normalize candidate signals, score freshness, rank results and inspect the reasons. |
+| **Source profiles and decisions** | Interpret context for a source class and task: use, cite, background, refresh, verify, watch or exclude. |
+| **Provenance helpers** | Inspect source and timing completeness and prepare content identity material when inputs are available. |
+| **MCP and reference adapters** | Evaluate caller-provided context with `evaluate_context`, or invoke separate read-only adapters for source-specific intake. |
+| **Specification and deployment assets** | Build against documented contracts and inspect the Worker, storage and operational reference surfaces. |
+
+Core is available through `freshcontext-mcp/core`, with an edge entrypoint at `freshcontext-mcp/core/edge`. Hosted endpoints are versioned deployment surfaces and are verified separately from the package. See the [architecture boundary](#architecture-boundary).
+
+## Your platform, your product direction
+
+The existing evaluation foundation supports several directions. The product extensions below have explicit implementation and validation gates in the [roadmap](./docs/FUTURE_LANES.md#product-roadmap).
+
+| Direction | Product experience | Boundary |
+|---|---|---|
+| **Embedded evaluation** | Add context recommendations and reasons to your retrieval, memory or agent workflow. | Current Core interfaces; each host integration requires validation. |
+| **Context monitoring** | Show which information is aging, uncertain or due for review, with history and alerts. | Proposed dashboard and re-evaluation workflow. |
+| **Controlled enforcement** | Map recommendations to review, refresh or exclusion before context is used. | Proposed host policy layer; evaluation alone does not block a request. |
+| **Standalone or white-label delivery** | Package an experience under your own product design and operating model. | Proposed packaging route, with access, deployment, support and licensing requirements. |
+
+Start with one integration. Preserve the evaluation contract while choosing the user experience, connectors and operating policies that fit your platform. Monitoring and enforcement can share the same decision outputs; white-label is a delivery choice for either route.
 
 ---
 
 ## The problem
 
-Large language models retrieve web data semantically. Cosine similarity finds the documents that match a query best — but cosine doesn't know when a document was written.
+Semantic relevance does not establish whether information is current, traceable or suitable for a particular task. A retriever can return a strong textual match whose date is missing, whose content is old, or whose extraction failed.
 
-So a 2022 blog post and a 2026 paper can score nearly identically. The model gets a context window full of stale documents and faithfully summarizes 2022 advice for a 2026 question.
+FreshContext makes those signals and their implications visible before the application assembles model context. It judges context usefulness and uncertainty; it does not certify truth.
 
-That's not hallucination. That's correct summarization of corrupted retrieval.
-
-> **Most RAG pipelines rank context correctly semantically but incorrectly temporally.**
+The project started with a practical failure: I asked Claude to help me find a job. It returned openings with equal confidence, including jobs that had already closed. FreshContext grew from that freshness problem into a reusable context-evaluation boundary.
 
 ---
 
@@ -39,7 +62,7 @@ candidate context
   -> model / agent / app
 ```
 
-FreshContext evaluates freshness, source profile, confidence, utility, provenance material, and failure honesty before context reaches the LLM. The temporal core uses Decay-Adjusted Relevancy:
+FreshContext evaluates freshness, source profile, confidence, provenance readiness and failure signals before context reaches the LLM. Context-conditioned utility is returned as an explanatory sidecar; it does not control default ranking or decision labels. The temporal core uses Decay-Adjusted Relevancy:
 
 ```
 R_t = R_0 · e^(−λt)
@@ -50,9 +73,9 @@ R_t = R_0 · e^(−λt)
 - `t` — hours elapsed since publication
 - `R_t` — decay-adjusted relevancy at query time
 
-That's the core correction. No model swap. No re-embedding. No re-indexing. The layer drops onto whatever retrieval pipeline you already have.
+The evaluation step can work with candidate signals from an existing retriever. The host maps its inputs to the signal contract and decides what to do with the outputs; integration effort depends on that host.
 
-**The layer is the product.** The named adapters shipped with this repo demonstrate compatibility across different source classes. The DAR engine, the freshness envelope, Source Profiles, and the FreshContext Specification are the moat.
+**The reusable boundary is the foundation.** The named adapters demonstrate source intake, while the Core, source profiles, decision semantics and specification provide a shared contract for product development.
 
 ---
 
@@ -452,9 +475,25 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 
 ## Roadmap
 
+The direction is **an existing evaluation foundation that teams can embed, observe and extend into controlled workflows**. The diagram separates current interfaces from proposed products; it is not a release schedule.
+
+```mermaid
+flowchart TD
+  core["Current: Core + MCP evaluation"] --> host["Validate one host integration"]
+  host --> embedded["Embed recommendations"]
+  host --> monitor["Proposed: monitoring + alerts"]
+  host --> control["Proposed: controlled enforcement"]
+  monitor --> product["Proposed: standalone / white-label delivery"]
+  control --> product
+```
+
+**Next bounded proof:** evaluate a fixed set of caller-provided signals, preserve the reasons, and display their history in an observation-only prototype. Re-evaluation, alerting and any automatic action are separate host work. See [Product roadmap](./docs/FUTURE_LANES.md#product-roadmap) for completion gates and [First monitoring slice](./docs/FUTURE_LANES.md#first-monitoring-slice) for the concrete build specification.
+
+### Existing milestones and implementation lanes
+
 - [x] FreshContext Specification v1.2 published (MIT, open standard)
 - [x] DAR engine with source-specific lambda constants
-- [x] Ha-Pri v1 provenance signatures on stored signals
+- [x] Ha-Pri v1 SHA-256 provenance references on stored signals
 - [x] Semantic deduplication via fingerprinting
 - [x] Live before/after demo at `/demo`
 - [x] METHODOLOGY.md — methodology and engineering documentation
@@ -466,9 +505,11 @@ Production: `https://freshcontext-mcp.gimmanuel73.workers.dev`
 - [x] Ha-Pri v2 Core helper and deterministic golden vectors
 - [x] Ha-Pri v2 production-enforcement design document
 - [ ] Ha-Pri v2 Worker/D1 production enforcement
-- [x] GitHub Actions release workflow — manual or `v*` tag-triggered npm publish path
+- [x] GitHub Actions verification and Worker deployment workflow; npm publication remains a separate manual release action
 - [ ] Webhook triggers — push high-entropy signals on threshold
-- [ ] Dashboard — React frontend for the D1 intelligence pipeline
+- [ ] Context monitoring — evaluation history, scheduled re-evaluation, dashboard and alerts
+- [ ] Controlled enforcement — explicit host policies, shadow evaluation, audit and rollback
+- [ ] Standalone / white-label delivery — product configuration, access boundaries and operating model
 - [ ] GKG upgrade for `extract_gdelt` — tone scores, goldstein scale, event codes
 
 Future work is organized in [FreshContext Future Lanes](./docs/FUTURE_LANES.md). Roadmap items are not live product claims until implemented and validated.

--- a/docs/FUTURE_LANES.md
+++ b/docs/FUTURE_LANES.md
@@ -1,10 +1,40 @@
 # FreshContext Future Lanes
 
-This document keeps future FreshContext work organized without turning roadmap ideas into public claims.
+Build your context-integrity product on an existing evaluation foundation. This roadmap describes how the current Core/MCP package can support embedded evaluation, context monitoring and controlled workflows, with standalone or white-label delivery as a packaging choice.
 
 FreshContext is live today as an integrated MCP/Core package. Future work should stay in lanes, start with audits, and avoid feature sprawl.
 
 The current package boundary is documented in [Core / MCP Boundary](./CORE_MCP_BOUNDARY.md). Treat MCP as the first live host over FreshContext Core, not as the whole product identity.
+
+## Product roadmap
+
+The current Core produces recommendations and explanations. The host owns persistence, scheduling, user access and any action taken from those recommendations. A dashboard makes decisions visible; an enforcement integration makes a chosen policy operational.
+
+These are completion gates rather than promised delivery dates. **Proposed** means work to implement and validate, not an available hosted feature.
+
+| Stage | Deliverable | Evidence required to complete it | Existing lane |
+|---|---|---|---|
+| **Foundation: current** | Core evaluation, signal contract, source profiles, decision helpers, MCP and reference adapters. | Verify the selected package or deployment version and replay its documented examples. | Phase 0; lanes 1-2 |
+| **Integration baseline** | One host maps its candidate context to the existing contract and consumes the outputs. | Fixed fixtures, relevant release checks, recorded reasons, measured latency and decision errors. | Lanes 1-3 |
+| **Observe: proposed** | Evaluation history, scheduled re-evaluation, dashboard and alerts. | Reproducible changes as information ages; unknown dates stay explicit; alerts deduplicate. | Lane 10 |
+| **Control: proposed, optional** | A host maps supported recommendations to review, refresh or exclusion. | Shadow evaluation, demonstrated allow/block behavior, timeout handling, overrides, audit and rollback. | Lanes 7, 9 and 11, as needed |
+| **Package: proposed, optional** | Embedded, standalone or white-label delivery of the chosen experience. | Configuration, access boundaries, deployment ownership, support, license review and compatibility. | Lanes 4 and 12, as needed |
+
+```mermaid
+flowchart TD
+  foundation["Existing evaluation foundation"] --> integration["Validate one host integration"]
+  integration --> embed["Embed in your platform"]
+  integration --> observe["Proposed: context monitoring"]
+  integration --> control["Proposed: controlled enforcement"]
+  observe --> package["Proposed: standalone / white-label"]
+  control --> package
+```
+
+A host can embed Core without building a dashboard. Monitoring can ship without automatic enforcement. An enforcement integration can use existing host observability rather than a new FreshContext dashboard. White-label describes how an experience is packaged; it is not a separate evaluation engine.
+
+Keep cryptographic verification as a distinct validation track: signing, verification and enforcement are different capabilities. Before claiming independently verifiable production attestations, prove public-key verification of a real deployed output, tamper rejection, key rotation/history and compatibility. Basic monitoring does not depend on completing that track.
+
+Product customization and release readiness are separate: teams choose connectors, dashboards, branding and policies; relevant tests, dependency review, runtime evidence and accurate documentation remain release requirements.
 
 ## Current Live Boundary
 
@@ -184,6 +214,58 @@ Operator may later select adapters, call retrievers, refresh stale sources, and 
 
 Not now. Operator is a later workflow layer over Core and adapters.
 
+## Lane 10: Context Monitoring
+
+Goal: make the state of context understandable over time, using the current evaluation contract as the foundation.
+
+Proposed host capabilities:
+
+- Persist evaluations with source identity, source profile, content date, retrieval time, evaluation time, engine version, recommendation and reasons.
+- Re-evaluate on an explicit schedule or source change; preserve prior evaluations rather than silently replacing them.
+- Display date confidence, provenance readiness and recommended next steps alongside the score.
+- Route and deduplicate alerts; assign an owner and record resolution.
+
+Do not equate retrieval time with publication time. A newly fetched page may still contain old information. A static score is not continuous monitoring, and a decreasing freshness score does not establish that the content is false.
+
+### First monitoring slice
+
+Build an observation-only prototype around one fixed, caller-provided source set. Use the current file-input demo to establish the evaluation boundary, then add the smallest host needed for history and display.
+
+| Scenario | What the prototype must show | Acceptance evidence |
+|---|---|---|
+| Dated signal evaluated again later | Content date, retrieval time and evaluation time remain distinct; any changed score or recommendation has a reason. | Replay using an explicit clock and declared source profile. Confirm the freshness calculation uses the intended time input. |
+| Missing or unreliable date | Uncertainty is visible and the profile-specific recommendation is preserved. | No invented timestamp and no silent conversion of unknown freshness into a fresh result. |
+| Failed source content | The failure and its reasons remain visible. | The failure fixture is not presented as usable, high-confidence context. |
+| Repeated evaluation with the same inputs | Results can be compared without duplicate alerts. | Stable decision behavior for the same engine, profile and clock; explicit alert deduplication. |
+
+The UI should answer: **What changed? Why? What needs attention? Who owns the next action?** Label all design fixtures as sample data until connected to actual evaluation events. This slice does not require autonomous crawling, billing or a new multi-agent framework.
+
+## Lane 11: Controlled Enforcement
+
+Goal: connect supported recommendations to explicit actions in a host workflow.
+
+Start in shadow mode: record what the policy would do without changing the application's behavior. Agree a finite mapping to allow, review, refresh or exclude actions, then measure incorrect exclusions and missed interventions before enabling enforcement.
+
+Completion requires:
+
+- Tests of allowed and blocked paths at the actual point where context enters reasoning.
+- Defined behavior for evaluator timeout, missing evidence and refresh failure, appropriate to the workflow's risk.
+- Explicit authorized overrides with a reason, policy version, actor and outcome.
+- Bounded refresh retries, observable failures and a rollback path.
+- A record linking each host action to its evaluation; a recommendation is not proof that an action occurred.
+
+Do not advertise a universal failsafe or truth certification. Expiry, revocation, source allowlists and cross-document conflicts require explicit support and validation before being promised. Lane 9 is needed only where the host must orchestrate retrieval or refresh; a host can instead use its own retriever.
+
+## Lane 12: Product Packaging and White-Label Delivery
+
+Goal: let teams choose the product experience and operating model around the shared evaluation contract.
+
+Possible forms are an embedded component, a standalone monitoring experience, or a white-label product built on monitoring and/or controlled enforcement. These are proposed packaging options, not claims of a finished enterprise service.
+
+Completion requires a defined configuration and theming surface, authentication and authorization, data and configuration isolation where multi-tenancy is offered, deployment and upgrade procedures, observability, support ownership and a third-party license/contributor inventory. See [LICENSE](../LICENSE), [NOTICE](../NOTICE.md) and [TRADEMARKS](../TRADEMARKS.md) for the current repository terms.
+
+Use the current Core subpath where it fits. Extract a standalone SDK only through Lane 4's dependency, compatibility and migration audit. Branding changes must not silently alter the signal contract or decision semantics.
+
 ## Operating Rule
 
 Every lane starts with:
@@ -193,4 +275,3 @@ audit -> small patch -> validation -> stop
 ```
 
 Do not combine lanes because the architecture is tempting.
-


### PR DESCRIPTION
FreshContext's README starts with a narrow freshness story, while the existing Core can be integrated into broader context-evaluation workflows. The roadmap lists individual features without showing how teams could turn that foundation into a product.

This change updates README.md and docs/FUTURE_LANES.md to:

- Lead with the existing Core/MCP evaluation foundation and preserve the original problem as project context.
- Distinguish current embedded evaluation from proposed monitoring, controlled enforcement and standalone/white-label delivery.
- Add Mermaid roadmap diagrams, completion gates and a bounded observation-only prototype specification.
- Preserve existing implementation lanes, setup instructions and API boundaries; clarify that hosts enforce actions and that utility remains a sidecar.
- Align the roadmap's workflow description with the current verification/Worker deployment workflow and manual npm publication.

Validation:

- npm run build: passed.
- npm run trust:gate: passed with zero fail findings; package gate and claim checks have zero warnings. The general scanner still reports 106 warnings.
- git diff --check: passed.
- Local Markdown links/anchors and balanced code fences: checked.

Only two documentation files changed. The proposed monitoring, enforcement and packaging capabilities are not implemented by this PR.