### PR TITLE
fix(worker): restore the workers.dev hostname that routes silently turned off

### DIFF
--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -32,6 +32,25 @@
   "routes": [
     { "pattern": "api.freshcontext.dev", "custom_domain": true }
   ],
+  // Explicit, because the default is conditional and that cost us a production deploy.
+  //
+  // The `routes` block above was added on the understanding that "the workers.dev hostname
+  // keeps working, so existing clients do not break at cutover." It does not. Adding routes
+  // without naming workers_dev turns the subdomain OFF, and the deploy of 2a53671 proved it
+  // in the only way that counts — wrangler listed the triggers it had just published:
+  //
+  //     Deployed freshcontext-mcp triggers (1.34 sec)
+  //       api.freshcontext.dev (custom domain)
+  //       schedule: 0 */6 * * *
+  //
+  // No workers.dev route in that list, and freshcontext-mcp.<subdomain>.workers.dev/health
+  // then answered 404 six times over thirty seconds. The smoke test rolled production back,
+  // which is exactly what it is for — but every MCP client config anyone has already copied
+  // points at that hostname, so leaving it off silently breaks all of them.
+  //
+  // Setting it explicitly also removes the conditional: this file now says which hostnames
+  // serve instead of depending on an interaction between two keys.
+  "workers_dev": true,
   "browser": {
     "binding": "BROWSER"
   },


### PR DESCRIPTION
**main is red and the public workers.dev endpoint is 404ing right now.** One line fixes it.

## What happened

[#72](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp/pull/72) added a `routes`
block for the `api.freshcontext.dev` custom domain, on the stated understanding that *"the
workers.dev hostname keeps working, so existing clients do not break at cutover."*

That understanding was wrong. Configuring `routes` without naming `workers_dev` turns the
subdomain off. The deploy of `2a53671` said so itself, in the list of triggers it had just
published:

```
Deployed freshcontext-mcp triggers (1.34 sec)
  api.freshcontext.dev (custom domain)
  schedule: 0 */6 * * *
```

No workers.dev route. The smoke test then asked
`freshcontext-mcp.<subdomain>.workers.dev/health` six times over thirty seconds:

```
curl: (22) The requested URL returned error: 404
attempt 1: /health did not answer
... ×6
::error::/health never returned the deployed commit SHA.
```

…and rolled production back to `103b0ad3`, the version deployed at 11:45Z for #69.
Run [34646316929](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp/actions/runs/34646316929).

**The pipeline did exactly its job.** This is the first time the rollback has fired on a
real regression rather than a fixture, and it caught a change whose own comment asserted
the opposite of what it did. Worth noting given how much of this week went into making the
smoke test able to tell a live deploy from a dead one.

## Why a rollback didn't fix it

Rolling back restores the Worker **version**. Routes and the workers.dev toggle are
deploy-time account configuration, not part of the version — so the rollback did not turn
the subdomain back on. It is still off. Every MCP client config anyone has copied points at
that hostname.

## The fix

```jsonc
"workers_dev": true,
```

Stated explicitly rather than inherited. wrangler 4.99.0's own `config-schema.json`
describes it as *"Whether we use `<name>.<subdomain>.workers.dev` to test and deploy your
Worker"* with a bare default of `true` — *bare* being the point: with `routes` present the
effective default flips. A default that depends on another key is precisely the shape of
bug this repo keeps finding. The file now names which hostnames serve instead of leaving it
to an interaction.

Both hostnames then serve, which is what #72 intended and documented.

## Honest limitation

`developers.cloudflare.com` is egress-blocked from this sandbox, so this rests on wrangler's
bundled schema plus the deploy's own trigger list and six 404s — observation of production
rather than a quoted doc sentence. `--dry-run` does not publish or print triggers, so the
trigger list of the **next real deploy** is the proof, and the smoke test is what checks it.
If workers.dev still 404s after this merges, the smoke test will roll back again and say so.

## Not fixed here

Nothing verifies `api.freshcontext.dev`. It is now the published endpoint and the smoke test
never asks it anything, so it could stop serving and no one would find out. Left out
deliberately: a custom domain's certificate can take minutes to issue, and a smoke assertion
against it tonight could roll back a perfectly good deploy. Worth adding once the domain has
settled — happy to do it as a follow-up.

## Also ported

The same commit is cherry-picked onto
[#73](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp/pull/73), so the two can merge
in either order and it no-ops once the base carries it. Without it, merging #73 would deploy,
404, roll back, and the Ed25519 public key would never actually publish.

## Verification

```
worker tsc clean · 25/25 worker · wrangler deploy --dry-run clean, 6/6 bindings
wrangler.jsonc parses with workers_dev, routes and compatibility_date intact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbBinv5qSeDFLB65894UQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbBinv5qSeDFLB65894UQm)_