### PR TITLE
Fix main: the custom domain silently turned off workers.dev

### DIFF
--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -32,6 +32,19 @@
   "routes": [
     { "pattern": "api.freshcontext.dev", "custom_domain": true }
   ],
+
+  // Keep the workers.dev hostname serving alongside the custom domain. Wrangler
+  // turns workers.dev OFF whenever `routes` is present and this is not set, which
+  // is exactly what happened when the route above first landed: the deploy
+  // succeeded, freshcontext-mcp.<subdomain>.workers.dev began answering 404, the
+  // smoke test (which targets it via WORKER_BASE_URL) failed six attempts, and CI
+  // rolled production back. Twice, on two separate merges.
+  //
+  // It must stay true for as long as anything points at the workers.dev host:
+  // WORKER_BASE_URL, the published MCP registry entry, and every client config
+  // copied before the cutover. Setting it false is a deliberate retirement of that
+  // hostname, not a cleanup.
+  "workers_dev": true,
   "browser": {
     "binding": "BROWSER"
   },


### PR DESCRIPTION
## main is red and production is serving stale code. This is the fix.

**Not a draft.** `main` has failed on its last two merges and production has been automatically rolled back twice. Both were caused by the `routes` block I added in #72 — and #72's description asserted the opposite of what actually happened.

## What broke

Wrangler disables the `workers.dev` subdomain whenever `routes` is present and `workers_dev` is not explicitly set. #72 added the `api.freshcontext.dev` custom domain and did not set it, so the first deploy carrying that route turned `freshcontext-mcp.<subdomain>.workers.dev` **off**.

The CI smoke test targets exactly that host via `WORKER_BASE_URL`. From the deploy job on `2a53671`:

```
BASE: https://freshcontext-mcp.<subdomain>.workers.dev
curl: (22) The requested URL returned error: 404     ×6
##[error]/health never returned the deployed commit SHA.
##[warning]Smoke test failed — rolling back.
✓ Worker Version 103b0ad3… has been deployed to 100% of traffic.
```

**The deploy itself succeeded every time.** The Worker was live on the custom domain, answering correctly — at a hostname the smoke test doesn't know about. The pipeline did exactly what it was built to do and rolled back a good deploy.

## Current state

| | |
|---|---|
| Production Worker version | `103b0ad3` — the **#69** build, from 11:45 |
| #72 code live? | **No** |
| #74 code live? | **No** |
| Last green `main` | `49ba341` (#69) |

## My error, stated plainly

#72 claimed: *"The `workers.dev` hostname keeps working, so existing clients do not break at cutover."*

That was **asserted, not tested, and wrong**. `wrangler deploy --dry-run` — which I did run, and which passed — does not touch routing, and no test covers deployment topology. The claim read as reasonable in review and was false in production.

## The fix

One line, plus the reasoning recorded beside it so the next person to tidy up a "redundant" flag finds out what it's load-bearing for:

```jsonc
"workers_dev": true,
```

It must stay `true` while anything still points at that host: `WORKER_BASE_URL`, the published MCP registry entry, and every client config copied before the cutover. Turning it off is a deliberate retirement of that hostname, not a cleanup.

## Verification

- `npm test` — **411/411 pass**
- worker tests — **25/25 pass**
- worker `tsc --noEmit` — clean
- `npm run trust:gate` — clean
- `wrangler deploy --dry-run` — clean, all six bindings resolve

The dry run passing is exactly why this needs the config comment rather than trusting the next review to catch it.

## Deliberately not fixed here — decisions, not defects

- **`WORKER_BASE_URL` still points at `workers.dev`.** Pointing it at `api.freshcontext.dev` would make the smoke test prove the domain users are actually told to use. That's a better test and a repository-variable change, not a code change — your call.
- **Nothing in CI asserts the custom domain answers at all.** The smoke test proves one hostname; the Worker now has two.

## Merge order

This should go in **before** #73 (the Ed25519 public key). #73 also edits `worker/wrangler.jsonc`, but additively and at a different location, so they don't conflict. Merging #73 onto a red main would deploy, fail the same smoke test, and roll back — taking the key publication with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL)_