### PR TITLE
Record Ed25519 attestation as shipped, and keep the Ha-Pri scope honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ The reference implementation runs on Cloudflare's global edge:
 | `/briefing` | GET | Latest stored briefing |
 | `/v1/intel/feed/:profile_id` | GET | DAR-scored intelligence feed |
 | `/watched-queries` | GET | List all watched queries |
+| `/.well-known/freshcontext-signing-keys.json` | GET | Published Ed25519 verification keys (active + retired) |
 
 - **D1 database** — 18 watched queries running on 6-hour cron with relevancy scoring
 - **KV-backed rate limiting** — 60 req/min per IP across all edge nodes
@@ -479,7 +480,7 @@ Split three ways so that genuine engineering risk is never filed as optionality.
 - [x] DAR engine with source-specific lambda constants
 - [x] Ha-Pri v1 provenance signatures on stored signals
 - [x] Ha-Pri v2 Core helper and deterministic golden vectors
-- [x] Public `/v1/verify` endpoint — HMAC-signed, ledger-backed verdict verification
+- [x] Public `/v1/verify` endpoint — ledger-backed verdict verification, answering for both the legacy HMAC path and Ed25519, and reporting which was used via `verification_method`
 - [x] Generic MCP `evaluate_context` tool for caller-provided candidate context
 - [x] Core-backed envelope generation shared by npm/MCP and the Cloudflare Worker
 - [x] Semantic deduplication via fingerprinting
@@ -489,10 +490,26 @@ Split three ways so that genuine engineering risk is never filed as optionality.
 - [x] METHODOLOGY.md — methodology and engineering documentation
 - [x] Published on npm and listed for MCP usage; Apify/feed assets separated from the MCP runtime package
 - [x] GitHub Actions release workflow — manual or `v*` tag-triggered npm publish path
+- [x] **Independently verifiable Ed25519 attestation (E-2).** Every new verdict row in the
+  ledger is signed `FRESHCONTEXT_HA_PRI_V4` with Ed25519. A third party can verify a verdict
+  with no FreshContext account, no API key and no call to FreshContext — using the key
+  document the Worker publishes at `/.well-known/freshcontext-signing-keys.json` and either
+  verifier shipped in the npm tarball: `scripts/verify-offline.mjs` (Node, standard library)
+  or `scripts/verify_offline.py` (Python, no dependencies at all). Written up for the
+  sceptic rather than the maintainer in [VERIFYING.md](./docs/VERIFYING.md).
+- [x] Signing key `fc-2026-09-ceced1ab` published and active. Keys are append-only, so a
+  rotation never invalidates a verdict signed under a key that has since been retired.
+- [x] `attestation-proof.yml` — obtains a live verdict, verifies it with **both** shipped
+  verifiers, runs tampered-payload and tampered-signature negative controls, and confirms
+  the stored ledger row is V4 rather than only the emitted response block. On demand and
+  daily; every input it uses is public, so it needs no credentials to run.
 
 In flight on the core, not an expansion surface:
 
-- [ ] Ha-Pri v2 Worker/D1 production enforcement (design document complete; hard tamper enforcement not yet live)
+- [ ] Ha-Pri v2 Worker/D1 production enforcement for stored **signals** — the feed rows,
+  which still carry Ha-Pri v1 SHA-256 stamps. This is a separate path from the verdict
+  ledger above: verdicts are V4/Ed25519 today, signals are not. Design document complete;
+  hard tamper enforcement on the signals path is not live.
 
 ### Expansion surfaces — deliberately open, not built
 

--- a/docs/ED25519_ATTESTATION.md
+++ b/docs/ED25519_ATTESTATION.md
@@ -1,6 +1,18 @@
 # E-2 — Ed25519 Attestation and Independent Verification
 
-**Status:** implementation branch; not a production claim until keys are configured and the Worker is deployed and verified.
+**Status:** live in production and proven against it.
+
+Key `fc-2026-09-ceced1ab` is installed and published, the Worker signs every new ledger row
+`FRESHCONTEXT_HA_PRI_V4`, and the `attestation-proof` workflow has obtained a real verdict
+from production and verified it with both shipped verifiers — including the negative
+controls and a ledger round-trip confirming the *stored* row is V4, not merely the emitted
+block ([run 34649322932](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp/actions/runs/34649322932)).
+
+That run is what closes the gap this document used to hold open. Configuration alone could
+not: a published public key that is not the pair of the installed private secret produces
+verdicts that look perfectly well-formed and fail for every third party who checks, and
+unverifiable is indistinguishable from forged. The proof rules that out with evidence
+rather than assurance, and re-runs daily.
 
 ## Why this exists
 


### PR DESCRIPTION
Docs only. Two files, no code paths touched.

## The problem

The roadmap's production core predated E-2 and never mentioned it. The README was **understating the repository** — independent offline verification is arguably the most defensible thing in it, and a reader could not tell it existed.

Meanwhile `docs/ED25519_ATTESTATION.md` still opened with:

> **Status:** implementation branch; not a production claim until keys are configured and the Worker is deployed and verified.

All three conditions are now met.

## What's claimed, and why each is checkable

| Claim | How a reader checks it |
|---|---|
| Every new verdict row is signed `FRESHCONTEXT_HA_PRI_V4` | `/v1/verify` on any recent `verdict_id` |
| A third party can verify offline with no account, no API key, no call to us | Run either shipped verifier against the published key document |
| Both verifiers ship in the npm tarball | `files[]` names `docs/VERIFYING.md`, `scripts/verify-offline.mjs`, `scripts/verify_offline.py` — verifiable from the package, not taken on trust |
| Keys are append-only | Retired keys stay in the published document; covered by the rotation tests |

Also adds `/.well-known/freshcontext-signing-keys.json` to the endpoint table — it's a public endpoint that verification depends on and wasn't listed — and widens the `/v1/verify` line to say it answers for both signature families and reports which via `verification_method`.

## The Ha-Pri item is narrowed, not removed

This is the part worth reviewing carefully.

V4 covers the **verdict ledger**. Stored **signals** still carry Ha-Pri v1 SHA-256 stamps, and hard tamper enforcement there is not live. Leaving the old wording sitting next to a shiny new Ed25519 claim would have invited the reading that signing now covers everything — which is the exact collapse this roadmap split exists to prevent. So the in-flight line now names which path it means and says plainly that verdicts are V4 and signals are not.

## Evidence

From `attestation-proof` [run 34649322932](https://github.com/PrinceGabriel-lgtm/freshcontext-mcp/actions/runs/34649322932) on `e3d441a`:

```json
{"status":"valid","signature_version":"FRESHCONTEXT_HA_PRI_V4",
 "key_id":"fc-2026-09-ceced1ab","verification_method":"ed25519","reasons":[]}
```
```
ok    the ledger row verifies as ed25519, independently of the emitted block
```

All eleven steps ran, **none skipped** — including the tampered-payload and tampered-signature negative controls, without which a verifier hardcoded to exit 0 would have "proven" every row.

That run is what closes the gap the doc used to hold open. Configuration alone could not: a published public key that is not the pair of the installed private secret yields verdicts that look perfectly well-formed and fail for every third party who checks, and unverifiable is indistinguishable from forged.

## Verification

- `npm test` — **411/411 pass**
- `npm run build` — clean
- `npm run trust:gate` — clean, **including its claim checks**, which is the gate that matters for a commit whose entire content is claims

## Note on this branch

The branch was reset from `main` before this work. Its previous commit was my duplicate `workers_dev` fix from the closed #76 — redundant once #75 landed that line on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL)_