### PR TITLE
Route NOTICE.md security reports to the domain, not a personal inbox

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -14,4 +14,4 @@ This notice does not grant trademark registration, partnership status, certifica
 
 Security reports and trust questions may be sent to:
 
-gimmanuel73@gmail.com
+security@freshcontext.dev


### PR DESCRIPTION
One line. Found by a sweep of every public claim across the repositories.

## The problem

`NOTICE.md` was the last file here publishing a personal Gmail address — and it published it as the **security intake**, while `SECURITY.md`, three files away, already directed the same reports to `security@freshcontext.dev`.

Two different intake addresses for the same purpose is worse than either alone: a reporter picks one, and whichever they pick they can't tell whether it's the one being read.

`NOTICE.md` is also the file that talks about *"packaged diligence review"*, which makes it a poor place to leave a personal mailbox as the contact of record.

`security@freshcontext.dev` is an explicit Cloudflare Email Routing rule, not a catch-all fallback, so it resolves independently of whether the catch-all stays enabled.

## What the sweep found clean in this repo

| Checked | Result |
|---|---|
| Personal Gmail in tracked files | **None remaining** after this change |
| README relative links | All resolve |
| `docs/*.md` referenced but absent | None |
| References to archived `freshcontext-worker` | None |
| Version consistency | `0.5.1` across `package.json` and `server.json` |
| Tool count | 22 `registerTool` sites — matches the profile's "22 tools live" and the site's "21 named adapters" (21 + `evaluate_context`) |

The surviving `pages.dev` and `0.3.21` mentions live in dated changelog entries on the site and record what was true at the time. They stay.

## Related

`freshcontext-site#10` fixes the other defect the sweep turned up: this repo's `freshcontext.schema.json` declares `$id: https://freshcontext.dev/freshcontext.schema.json`, and nothing served it. That PR serves it and adds a drift check comparing the published mirror against the canonical copy here.

**This repo stays canonical for the schema.** Edit it here; the mirror follows, and the site's CI fails if it doesn't.

## Verification

- `npm test` — **411/411 pass**
- `npm run build` — clean
- `npm run trust:gate` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018j5vYzbHW7GWfKXhgR2xHL)_